### PR TITLE
Fix bugs in tts.py

### DIFF
--- a/glados/tts.py
+++ b/glados/tts.py
@@ -436,12 +436,13 @@ class TTSEngine:
         for sentence in phonemes:
             audio_chunk = self.synthesizer.say_phonemes(sentence)
             audio.append(audio_chunk)
-        audio = np.concatenate(audio, axis=1).T
+        if audio:
+            audio = np.concatenate(audio, axis=1).T
         return audio
 
 
 if __name__ == "__main__":
     tts = TTSEngine(MODEL_PATH, USE_CUDA)
-    audio = tts._generate_audio("Hello world. How are you?")
-    sd.play(audio.T, RATE)
-    sd.sleep(int(1000 * audio.shape[1] / RATE))
+    audio = tts.generate_speech_audio("Hello world. How are you?")
+    sd.play(audio, RATE)
+    sd.wait()


### PR DESCRIPTION
- If you input text that is entirely silent, such as ".......", the audio array will be empty, and therefore np.concatenate will fail. This adds a check for that.
- The example code was using an old function name that has since been renamed.
- It was also transposing the audio when the function already did that.
- At least for me, the sd.sleep call was far too short to actually hear any audio. Using sd.wait sleeps for exactly the right time, without having to calculate it manually.

Very cool project, looking forward to this being completed with a full on hardware rig. :thumbsup:

Some things I'll probably look into after this:
- Figuring out if there's a way to register the TTS with `espeak` directly, so that other programs too can use GlaDOS's voice.
- Using the referenced distil-whisper as ggml-medium-32-2 linked in the installation instructions seems to take far too long to be real-time on my laptop for some reason.
- Hooking up an LLM to llm.py via a server using the OpenAI API, so that the LLM can keep running when the TTS is restarted.

Let me know if you're interested in pull requests upstream for any of those.