### PR TITLE
Fix performance issue when using CUDA provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Don't want to compile anything?  Try this simplified process, but be aware it's 
  
 
 1. Open the Microsoft Store, search for `python` and install Python 3.12.
-   a. If you want to use python 3.10, install `typing_extensions` and replace `import typing` in `glados/llama.py` with `import typing_extensions`
+   a. To use Python 3.10, install `typing_extensions` and replace `import typing` in `glados/llama.py` with `import typing_extensions`.
 2. Download and unzip this repository somewhere in your home folder.
 3. Run the `install_windows.bat`. During the process, you will be prompted to install eSpeak-ng, which is necessary for GLaDOS's speech capabilities. This step also downloads the Whisper voice recognition model and the Llama-3 8B model.
 4. Once this is all done, you can initiate  GLaDOS with the `start_windows.bat` script.

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Don't want to compile anything?  Try this simplified process, but be aware it's 
  
 
 1. Open the Microsoft Store, search for `python` and install Python 3.12.
+   a. If you want to use python 3.10, install `typing_extensions` and replace `import typing` in `glados/llama.py` with `import typing_extensions`
 2. Download and unzip this repository somewhere in your home folder.
 3. Run the `install_windows.bat`. During the process, you will be prompted to install eSpeak-ng, which is necessary for GLaDOS's speech capabilities. This step also downloads the Whisper voice recognition model and the Llama-3 8B model.
 4. Once this is all done, you can initiate  GLaDOS with the `start_windows.bat` script.

--- a/glados/tts.py
+++ b/glados/tts.py
@@ -223,7 +223,10 @@ class Synthesizer:
     ) -> onnxruntime.InferenceSession:
         providers = ["CPUExecutionProvider"]
         if use_cuda:
-            providers = ["CUDAExecutionProvider"]
+            providers = [
+                ("CUDAExecutionProvider", {"cudnn_conv_algo_search": "HEURISTIC"}),
+                "CPUExecutionProvider",
+            ]
 
         return onnxruntime.InferenceSession(
             str(model_path),


### PR DESCRIPTION
I encountered a huge performance issue when running the tts module on my RTX 3090 gpu instead of i9-14900k cpu.

I used some simple code to run single executions of the tts module for testing.

The time elapsed for gpu was over 30 seconds while cpu took only 0.09 - 0.11 seconds.

Based on an article I found, the solution is to change the `cudnn_conv_algo_search` options from "EXHAUSTIVE" (default) to "HEURISTIC" or "DEFAULT". I went with "HEURISTIC" as the article explains that leads to behavior similar to pyTorch's default. Additionally, both "DEFAULT" and "HEURISTIC" produced the same results.
(https://medium.com/neuml/debug-onnx-gpu-performance-c9290fe07459)

Now, my gpu time elapsed time has significantly decreased to taking 0.15 - 0.18 seconds. The gpu is expected to be slightly slower than cpu in this case as there is data being copied to the gpu at the start of inference, and data being copied back to the cpu after inference, which adds some overhead.

There was a page I read that explains adding `CPUExecutionProvider` (appearing after `CUDAExecutionProvider`) in the providers list will grant onnxruntime explicit permission to fallback to cpu for operations unsupported in CUDA (all the yellow warning messages). This behavior occurs by default anyways but it is better to explicitly allow this behavior.


Code used for testing
```from glados import tts

import sounddevice as sd

model_path = "models/glados.onnx"
text = "All neural network modules are now loaded."
rate = 22050

_tts = tts.Synthesizer(model_path=model_path, use_cuda=True)

audio = _tts.generate_speech_audio(text)

sd.play(audio, samplerate=rate)
sd.wait()

print("done")
```

Inside `glados/tts.py` I set the start_time at the beginning of the `generate_speech_audio` function and printed the elapsed time before returning the concatenated audio data.

```
def generate_speech_audio(self, text: str) -> np.ndarray:
        start_time = time.time()
        phonemes = self._phonemizer(text)
        audio = []
        for sentence in phonemes:
            audio_chunk = self._say_phonemes(sentence)
            audio.append(audio_chunk)
        if audio:
            print("returning audio", time.time() - start_time)
            return np.concatenate(audio, axis=1).T
        return np.array([])
```

I also added an instruction in the README for using python 3.10 instead of python 3.12.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved performance with CUDA execution support for text-to-speech when `use_cuda` is enabled.

- **Documentation**
	- Updated installation instructions to recommend Python 3.12 from the Microsoft Store.
	- Added guidance for using Python 3.10 with necessary adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->