### PR TITLE
Automatically detect path to `espeak` binary, and complain if not found

### DIFF
--- a/glados.py
+++ b/glados.py
@@ -2,6 +2,7 @@ import copy
 import json
 import queue
 import re
+import shutil
 import sys
 import threading
 import time
@@ -103,8 +104,18 @@ class Glados:
         self.wake_word = wake_word
         self._vad_model = vad.VAD(model_path=str(Path.cwd() / "models" / VAD_MODEL))
         self._asr_model = asr.ASR(model=str(Path.cwd() / "models" / ASR_MODEL))
-        self._tts = tts.Synthesizer(model_path=str(Path.cwd() / "models" / VOICE_MODEL), use_cuda=False)
-
+        if shutil.which("espeak-ng"):
+            espeak = "espeak-ng"
+        elif shutil.which("espeak"):
+            espeak = "espeak"
+        else:
+            logger.error("I cannot find `espeak` on your path. You probably "
+                                    "forgot to install it. How utterly embarrassing "
+                                    "for you.")
+            raise FileNotFoundError("Cannot find espeak")
+        self._tts = tts.Synthesizer(model_path=str(Path.cwd() / "models" / VOICE_MODEL),
+                                     use_cuda=False, espeak=espeak)
+ 
         # LLAMA_SERVER_HEADERS
         self.prompt_headers = {"Authorization": api_key or "Bearer your_api_key_here"}
 

--- a/glados.py
+++ b/glados.py
@@ -2,7 +2,6 @@ import copy
 import json
 import queue
 import re
-import shutil
 import sys
 import threading
 import time
@@ -104,17 +103,7 @@ class Glados:
         self.wake_word = wake_word
         self._vad_model = vad.VAD(model_path=str(Path.cwd() / "models" / VAD_MODEL))
         self._asr_model = asr.ASR(model=str(Path.cwd() / "models" / ASR_MODEL))
-        if shutil.which("espeak-ng"):
-            espeak = "espeak-ng"
-        elif shutil.which("espeak"):
-            espeak = "espeak"
-        else:
-            logger.error("I cannot find `espeak` on your path. You probably "
-                                    "forgot to install it. How utterly embarrassing "
-                                    "for you.")
-            raise FileNotFoundError("Cannot find espeak")
-        self._tts = tts.Synthesizer(model_path=str(Path.cwd() / "models" / VOICE_MODEL),
-                                     use_cuda=False, espeak=espeak)
+        self._tts = tts.Synthesizer(model_path=str(Path.cwd() / "models" / VOICE_MODEL), use_cuda=False)
  
         # LLAMA_SERVER_HEADERS
         self.prompt_headers = {"Authorization": api_key or "Bearer your_api_key_here"}

--- a/glados/tts.py
+++ b/glados/tts.py
@@ -214,9 +214,10 @@ class Synthesizer:
         Converts the given phonemes to audio.
     """
 
-    def __init__(self, model_path: str, use_cuda: bool):
+    def __init__(self, model_path: str, use_cuda: bool, espeak: str):
         self.session = self._initialize_session(model_path, use_cuda)
         self.id_map = PHONEME_ID_MAP
+        self._espeak = espeak
 
     def _initialize_session(
         self, model_path: str, use_cuda: bool
@@ -250,7 +251,7 @@ class Synthesizer:
         try:
             # Prepare the command to call espeak with the desired flags
             command = [
-                "espeak-ng",  # 'C:\Program Files\eSpeak NG\espeak-ng.exe',
+                self._espeak, # path to espeak eg 'C:\Program Files\eSpeak NG\espeak-ng.exe',
                 "--ipa=2",  # Output phonemes in IPA format
                 "-q",  # Quiet, no output except the phonemes
                 "--stdout",  # Output the phonemes to stdout


### PR DESCRIPTION
See Issue #58. The `espeak` binary can appear under different names, especially on MacOS. This checks for and uses the alternatives, and complains (bitterly) if not found

Closes #58 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of the `espeak` binary path to ensure compatibility and error logging if not found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->