### PR TITLE
Move startup into its own method.

### DIFF
--- a/glados.py
+++ b/glados.py
@@ -296,7 +296,7 @@ class Glados:
                 self.llm_queue.put(detected_text)
                 self.processing = True
                 self.currently_speaking = True
-        
+
         if not self.interruptible:
             while self.currently_speaking:
                 time.sleep(PAUSE_TIME)
@@ -540,7 +540,8 @@ class Glados:
         return line
 
 
-if __name__ == "__main__":
+def start() -> None:
+    """Set up the LLM server and start GlaDOS."""
     llama_server_config = LlamaServerConfig.from_yaml("glados_config.yml")
 
     llama_server = None
@@ -565,3 +566,6 @@ if __name__ == "__main__":
     glados = Glados.from_config(glados_config)
 
     glados.start_listen_event_loop()
+
+if __name__ == "__main__":
+    start()


### PR DESCRIPTION
Makes it easier to import glados into other modules (eg any UI that may happen to exist!)

Should probably move some files around to make everything PEP compliant. At the moment there is both a module and a package called `glados`, which plays havoc with installers, and necessitates monkey patching to get it installed properly.  But that is for another PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined the server setup and execution process by consolidating the main script logic into a new `start()` function.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->