### PR TITLE
Adding macOS installation instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,15 @@ Don't want to compile anything?  Try this simplified process, but be aware it's 
 3. Run the `install_windows.bat`. During the process, you will be prompted to install eSpeak-ng, which is necessary for GLaDOS's speech capabilities. This step also downloads the Whisper voice recognition model and the Llama-3 8B model.
 4. Once this is all done, you can initiate  GLaDOS with the `start_windows.bat` script.
 
+### *Even newer Simplified macOS Installation Process*
+This is still experimental, any issues can be helped in the discord server, if you create an issue related to this you will be reffered to the discord serer
+
+
+1. Install Python 3.12 from pythons website (https://www.python.org/downloads/release/python-3124/)
+2. (Optional) Install homebrew prior to running the `install_mac.sh`, if you dont do this it will install it for you (Not tested)
+3. `git clone` this repository using `git clone github.com/dnhkng/glados.git`
+4. Run the `install_mac.sh`. If you do not have python installed then you will run into an error
+5. Once this finishes run the `start_mac.sh` to start GLaDOS
 
 ## Regular installation
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ This is still experimental, any issues can be helped in the discord server, if y
 1. Install Python 3.12 from pythons website (https://www.python.org/downloads/release/python-3124/)
 2. (Optional) Install homebrew prior to running the `install_mac.sh`, if you dont do this it will install it for you (Not tested)
 3. `git clone` this repository using `git clone github.com/dnhkng/glados.git`
-4. Run the `install_mac.sh`. If you do not have python installed then you will run into an error
+4. Run the `install_mac.sh`. If you do not have Python installed, then you will run into an error.
 5. Once this finishes run the `start_mac.sh` to start GLaDOS
 
 ## Regular installation

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Don't want to compile anything?  Try this simplified process, but be aware it's 
 4. Once this is all done, you can initiate  GLaDOS with the `start_windows.bat` script.
 
 ### *Even newer Simplified macOS Installation Process*
-This is still experimental, any issues can be helped in the discord server, if you create an issue related to this you will be refered to the discord serer
+This is still experimental. Any issues can be addressed in the Discord server. If you create an issue related to this, you will be referred to the Discord server.
 
 
 1. Install Python 3.12 from pythons website (https://www.python.org/downloads/release/python-3124/)

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Don't want to compile anything?  Try this simplified process, but be aware it's 
 4. Once this is all done, you can initiate  GLaDOS with the `start_windows.bat` script.
 
 ### *Even newer Simplified macOS Installation Process*
-This is still experimental, any issues can be helped in the discord server, if you create an issue related to this you will be reffered to the discord serer
+This is still experimental, any issues can be helped in the discord server, if you create an issue related to this you will be refered to the discord serer
 
 
 1. Install Python 3.12 from pythons website (https://www.python.org/downloads/release/python-3124/)

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ This is still experimental, any issues can be helped in the discord server, if y
 
 
 1. Install Python 3.12 from pythons website (https://www.python.org/downloads/release/python-3124/)
-2. (Optional) Install homebrew prior to running the `install_mac.sh`, if you dont do this it will install it for you (Not tested)
+2. (Optional) Install Homebrew before running the `install_mac.sh`. If you don't do this, it will install it for you (Not tested).
 3. `git clone` this repository using `git clone github.com/dnhkng/glados.git`
 4. Run the `install_mac.sh`. If you do not have Python installed, then you will run into an error.
 5. Once this finishes run the `start_mac.sh` to start GLaDOS


### PR DESCRIPTION
Adding the installation instructions for macOS into the README

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a section in the README to detail an experimental macOS installation process for GLaDOS. This includes steps for installing Python 3.12, cloning the repository, and running specific scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->