### PR TITLE
Fix: UI read .ansi files with UTF-8 encoding, UI launch bat

### DIFF
--- a/glados-ui.py
+++ b/glados-ui.py
@@ -118,7 +118,7 @@ class Typewriter(Static):
 class SplashScreen(Screen):
     """Splash screen shown on startup."""
 
-    with open(Path("./glados_ui/images/splash.ansi")) as f:
+    with open(Path("./glados_ui/images/splash.ansi"), 'r', encoding='utf-8') as f:
         SPLASH_ANSI = Text.from_ansi(f.read(), no_wrap=True, end="")
 
     def compose(self) -> ComposeResult:
@@ -182,7 +182,7 @@ class GladosUI(App):
 
     SUB_TITLE = "(c) 1982 Aperture Science, Inc."
 
-    with open(Path("./glados_ui/images/logo.ansi")) as f:
+    with open(Path("./glados_ui/images/logo.ansi"), 'r', encoding='utf-8') as f:
         LOGO_ANSI = Text.from_ansi(f.read(), no_wrap=True, end="")
 
     def compose(self) -> ComposeResult:

--- a/start_windows_UI.bat
+++ b/start_windows_UI.bat
@@ -1,0 +1,5 @@
+@echo off
+REM Start GLaDOS
+
+call .\venv\Scripts\activate
+python glados-ui.py


### PR DESCRIPTION
Windows system language during installation affects how ascii and ansi characters are interpreted and Unicode UTF-8 is generally preferred for universal compatibility. 



**Issue**: The console output of `glados-ui.py` running into an error because encoding isn't specified:

```batchfile
Traceback (most recent call last):
  File "E:\GlaDOS\glados-ui.py", line 118, in <module>
    class SplashScreen(Screen):
  File "E:\GlaDOS\glados-ui.py", line 122, in SplashScreen
    SPLASH_ANSI = Text.from_ansi(f.read(), no_wrap=True, end="")
                                 ^^^^^^^^
  File "C:\Users\USERNAME\AppData\Local\Programs\Python\Python312\Lib\encodings\cp1252.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
UnicodeDecodeError: 'charmap' codec can't decode byte 0x81 in position 617: character maps to <undefined>
Press any key to continue . . .
``` 









**Changes**:
* **Encoding Fix**: Updated the file reading method for `splash.ansi` and `logo.ansi` to use UTF-8 encoding to prevent errors.
* **New Batch Script**: Added a batch script `start_windows_UI.bat` to activate the virtual environment and run `glados-ui.py`

**Note**: I'm not sure if the art displays correctly, so I've recorded a clip of it after the fix. Don't mind the black borders, it's OBS canvas not set-up correctly.

https://github.com/user-attachments/assets/83d76dfd-7b4c-440b-848b-4c5ac584ad4a



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a batch script for easier startup of the GLaDOS user interface, simplifying the launch process for users.
- **Improvements**
	- Enhanced file reading capabilities by specifying UTF-8 encoding for better handling of special characters in splash screen and logo files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->