### PR TITLE
fix css parsing error

### DIFF
--- a/glados_ui/glados.tcss
+++ b/glados_ui/glados.tcss
@@ -16,7 +16,6 @@ $primary: #ffb000;
 $foreground: #ffb000;
 $background: #282828;
 $surface: $background;
-$panel: $background;
 
 
 


### PR DESCRIPTION
Fixes the parsing error reported at https://github.com/dnhkng/GlaDOS/pull/82#issuecomment-2565391239

Seems to have been caused by recent changes in the Textual GUI library

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Removed a styling variable in the GlaDOS UI theme
	- Maintained existing color scheme and layout consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->