### PR TITLE
Remove TensorRT from list of providers in phonemizer.py

### DIFF
--- a/glados/phonemizer.py
+++ b/glados/phonemizer.py
@@ -108,11 +108,15 @@ class Phonemizer:
         self.phoneme_dict = self._load_pickle(self.config.PHONEME_DICT_PATH)
         self.token_to_idx = self._load_pickle(self.config.TOKEN_TO_IDX_PATH)
         self.idx_to_token = self._load_pickle(self.config.IDX_TO_TOKEN_PATH)
-
+        
+        providers = ort.get_available_providers()
+        if "TensorrtExecutionProvider" in providers:
+            providers.remove("TensorrtExecutionProvider")
+        
         self.ort_session = ort.InferenceSession(
             self.config.MODEL_NAME,
             sess_options=ort.SessionOptions(),
-            providers=ort.get_available_providers(),
+            providers=providers,
         )
 
         self.special_tokens: set[str] = {


### PR DESCRIPTION
This removes the TensorRT warnings that are thrown when the module is initialized.

This is a fix that was applied to `tts.py` in commit 0023cb585e6ccf1967d5b4744a126773882a89a1 but was not applied to `phonemizer.py`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved ONNX runtime session configuration by removing the TensorRT execution provider.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->