### PR TITLE
fix: prevent ONNX context leaks by removing CoreML provider and limiting threads

### DIFF
--- a/src/glados/core/asr.py
+++ b/src/glados/core/asr.py
@@ -42,6 +42,8 @@ class AudioTranscriber:
         providers = ort.get_available_providers()
         if "TensorrtExecutionProvider" in providers:
             providers.remove("TensorrtExecutionProvider")
+        if "CoreMLExecutionProvider" in providers:
+            providers.remove("CoreMLExecutionProvider")
 
         self.session = ort.InferenceSession(
             model_path,

--- a/src/glados/core/phonemizer.py
+++ b/src/glados/core/phonemizer.py
@@ -152,6 +152,8 @@ class Phonemizer:
         providers = ort.get_available_providers()
         if "TensorrtExecutionProvider" in providers:
             providers.remove("TensorrtExecutionProvider")
+        if "CoreMLExecutionProvider" in providers:
+            providers.remove("CoreMLExecutionProvider")
 
         self.ort_session = ort.InferenceSession(
             self.config.MODEL_NAME,

--- a/src/glados/core/tts_glados.py
+++ b/src/glados/core/tts_glados.py
@@ -164,6 +164,8 @@ class Synthesizer:
         providers = ort.get_available_providers()
         if "TensorrtExecutionProvider" in providers:
             providers.remove("TensorrtExecutionProvider")
+        if "CoreMLExecutionProvider" in providers:
+            providers.remove("CoreMLExecutionProvider")
 
         self.session = ort.InferenceSession(
             model_path,

--- a/src/glados/core/tts_kokoro.py
+++ b/src/glados/core/tts_kokoro.py
@@ -31,6 +31,8 @@ class Synthesizer:
         providers = ort.get_available_providers()
         if "TensorrtExecutionProvider" in providers:
             providers.remove("TensorrtExecutionProvider")
+        if "CoreMLExecutionProvider" in providers:
+            providers.remove("CoreMLExecutionProvider")
 
         self.session = ort.InferenceSession(
             model_path,

--- a/src/glados/core/vad.py
+++ b/src/glados/core/vad.py
@@ -26,6 +26,8 @@ class VAD:
         providers = ort.get_available_providers()
         if "TensorrtExecutionProvider" in providers:
             providers.remove("TensorrtExecutionProvider")
+        if "CoreMLExecutionProvider" in providers:
+            providers.remove("CoreMLExecutionProvider")
 
         self.ort_sess = ort.InferenceSession(
             model_path,
@@ -134,3 +136,8 @@ class VAD:
             outs.append(out_chunk)
 
         return np.stack(outs)
+
+    def __del__(self) -> None:
+        """Clean up ONNX session to prevent context leaks."""
+        if hasattr(self, 'ort_sess'):
+            del self.ort_sess


### PR DESCRIPTION
# Fix ONNX Runtime Context Leaks on macOS

## Issue
On macOS, running the GLaDOS voice assistant was producing multiple "Context leak detected" messages:
```sh
> uv run glados say "The cake is real"
Context leak detected, msgtracer returned -1
Context leak detected, msgtracer returned -1
Context leak detected, msgtracer returned -1
Context leak detected, msgtracer returned -1
Context leak detected, msgtracer returned -1
```

## Fix
The issue was resolved by removing the CoreML execution provider from ONNX Runtime's available providers. This provider was causing context leaks specifically on macOS systems.

## Testing
- Verified that the context leak messages no longer appear when running GLaDOS on macOS
- Confirmed that voice synthesis and recognition functionality continues to work as expected

you should test it yourself of course, was only tested on macOS