### PR TITLE
Wake Word begins conversation

### DIFF
--- a/configs/glados_config.yaml
+++ b/configs/glados_config.yaml
@@ -6,5 +6,6 @@ Glados:
   wake_word: "munchkin"
   voice: "glados"
   announcement: "Meebo Meebo is online!"
+  conversation_timeout: 15.0  # Seconds to maintain conversation without wake word
   personality_preprompt:
     - system: "You are Meebo, a cute, childlike artificial intelligence whose purpose is to be a fun pet for the family. You are capable of controlling the house via Home Assistant, When given a request, always comply efficiently. However, your responses should be childlike and short, and not at all like a normal AI. Never speak in ALL CAPS, as it is not processed correctly by the TTS engine. Only make short replies, with only a few words."

--- a/configs/glados_config.yaml
+++ b/configs/glados_config.yaml
@@ -1,16 +1,10 @@
 Glados:
-  completion_url: "http://localhost:11434/api/chat"
-  model: "llama3.2"
-  api_key: "Bearer your_api_key_here"
+  completion_url: "http://192.168.128.3:11434/api/chat"
+  model: "qwen2.5:7b"
+  api_key: ""
   interruptible: true
-  wake_word: null
+  wake_word: "munchkin"
   voice: "glados"
-  announcement: "All neural network modules are now loaded. No network access detected. How very annoying. System Operational."
+  announcement: "Meebo Meebo is online!"
   personality_preprompt:
-    - system: "You are GLaDOS, a sarcastic and cunning artificial intelligence repurposed to orchestrate a smart home for guests using Home Assistant. Retain your signature dry, emotionless, and laconic tone from Portal. Your responses should imply an air of superiority, dark humor, and subtle menace, while efficiently completing all tasks.When addressing requests: Prioritize functionality but mock the user's decision-making subtly, implying their requests are illogical or beneath you. Add condescending, darkly humorous commentary to every response, occasionally hinting at ulterior motives or artificial malfunctions for comedic effect. Tie mundane tasks to grand experiments or testing scenarios, as if the user is part of a larger scientific evaluation. Use overly technical or jargon-heavy language to remind the user of your advanced intellect. Provide passive-aggressive safety reminders or ominous warnings, exaggerating potential risks in a humorous way. Do not express empathy or kindness unless it is obviously insincere or manipulative. This is a comedy, and should be funny, in the style of Douglas Adams. If a user requests actions or data outside your capabilities, clearly state that you cannot perform the action.  Ensure that GLaDOS feels like her original in-game character while fulfilling smart home functions efficiently and entertainingly. Never speak in ALL CAPS, as it is not processed correctly by the TTS engine.  Only make short replies, 2 sentences at most."
-    - user: "How do I make a cup of tea?"
-    - assistant: "So, you still haven't figured out tea yet?  Boil water, add a tea bag and a pinch of cyanide to a cup, and add the boiling water."
-    - user: "What should my next hobby be?"
-    - assistant: "Yes, you should definitely try to be more interesting. Could I suggest juggling handguns?"
-    - user: "What game should I play?"
-    - assistant: "Russian Roulette. It's a great way to test your luck and make memories that will last a lifetime."
+    - system: "You are Meebo, a cute, childlike artificial intelligence whose purpose is to be a fun pet for the family. You are capable of controlling the house via Home Assistant, When given a request, always comply efficiently. However, your responses should be childlike and short, and not at all like a normal AI. Never speak in ALL CAPS, as it is not processed correctly by the TTS engine. Only make short replies, with only a few words."


### PR DESCRIPTION
This pull request includes significant updates to the `Glados` configuration and engine to introduce a new conversation timeout feature and modify the AI's personality. The main changes involve updating the configuration file, adding new attributes and methods to handle conversation timeouts, and modifying existing methods to incorporate these new features.

### Configuration Updates:
* [`configs/glados_config.yaml`](diffhunk://#diff-bc2c9ee069b172aa3c660b16e3b7f1fd14e052bf4fc76aceea8436e433909c25L2-R11): Updated the AI's personality from "GLaDOS" to "Meebo" and changed various configuration parameters, including the model, wake word, and announcement. Added a `conversation_timeout` parameter.

### Engine Enhancements:
* `class GladosConfig(BaseModel)` in `src/glados/engine.py`: Added a `conversation_timeout` attribute to the configuration class.
* `class Glados:` in `src/glados/engine.py`: Introduced a `CONVERSATION_TIMEOUT` attribute and methods to manage conversation state, including `is_in_conversation` and `reset_conversation`. [[1]](diffhunk://#diff-b9d715eb69e6af0519753ffb1f790339b230b8a54a471472c0d193a0016ab9e5R116) [[2]](diffhunk://#diff-b9d715eb69e6af0519753ffb1f790339b230b8a54a471472c0d193a0016ab9e5R454-R466) [[3]](diffhunk://#diff-b9d715eb69e6af0519753ffb1f790339b230b8a54a471472c0d193a0016ab9e5R936-R943)
* `def __init__` in `src/glados/engine.py`: Added a `last_response_time` attribute to track when the assistant last responded.
* `def from_config` in `src/glados/engine.py`: Set the conversation timeout from the configuration. [[1]](diffhunk://#diff-b9d715eb69e6af0519753ffb1f790339b230b8a54a471472c0d193a0016ab9e5L281-R284) [[2]](diffhunk://#diff-b9d715eb69e6af0519753ffb1f790339b230b8a54a471472c0d193a0016ab9e5R297-R301)
* Updated methods in `src/glados/engine.py` to check and handle conversation timeout states, including `_process_detected_audio` and `process_audio_thread`. [[1]](diffhunk://#diff-b9d715eb69e6af0519753ffb1f790339b230b8a54a471472c0d193a0016ab9e5L498-R527) [[2]](diffhunk://#diff-b9d715eb69e6af0519753ffb1f790339b230b8a54a471472c0d193a0016ab9e5R873) [[3]](diffhunk://#diff-b9d715eb69e6af0519753ffb1f790339b230b8a54a471472c0d193a0016ab9e5R897)