### PR TITLE
fix: added missing dependency for tui in windows

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "numba>=0.61.0",
     "soundfile>=0.13.0",
     "pydantic>=2.10.6",
+    "onnxruntime>=1.22.0",
 ]
 
 [project.optional-dependencies]

--- a/src/glados/cli.py
+++ b/src/glados/cli.py
@@ -288,6 +288,7 @@ def main() -> None:
     - 'download': Download required model files
     - 'start': Launch the GLaDOS voice assistant
     - 'say': Generate speech from input text
+    - 'tui': Launch the GLaDOS voice assistant, but with a Portal 2 themed terminal user interface
 
     The function sets up argument parsing with optional configuration file paths and handles
     command execution based on user input. If no command is specified, it defaults to starting


### PR DESCRIPTION
This is to prevent this error when running `uv run glados tui` on windows

ModuleNotFoundError: No module named ''onnxruntime"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new CLI command option, 'tui', described as launching the GLaDOS voice assistant with a Portal 2 themed terminal user interface.

- **Chores**
  - Updated dependencies to require onnxruntime version 1.22.0 or higher.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->