### PR TITLE
make TUI work after engine refactor

### DIFF
--- a/src/glados/tui.py
+++ b/src/glados/tui.py
@@ -2,7 +2,7 @@ from collections.abc import Iterator
 from pathlib import Path
 import random
 import sys
-from typing import Any, ClassVar, cast
+from typing import ClassVar, cast
 
 from loguru import logger
 from rich.text import Text
@@ -88,10 +88,16 @@ class Typewriter(Static):
         id: str | None = None,  # Consistent with typical Textual widget `id` parameter
         speed: float = 0.01,  # time between each character
         repeat: bool = False,  # whether to start again at the end
-        *args: str,  # Passed to super().__init__
-        **kwargs: str,  # Passed to super().__init__
+        # Static widget parameters
+        content: str = "",
+        expand: bool = False,
+        shrink: bool = False,
+        markup: bool = True,
+        name: str | None = None,
+        classes: str | None = None,
+        disabled: bool = False,
     ) -> None:
-        super().__init__(*args, **kwargs)  # Pass all kwargs to parent
+        # Initialize our custom attributes first
         self._text = text
         self.__id_for_child = id  # Store id specifically for the child VerticalScroll
         self._speed = speed
@@ -102,6 +108,18 @@ class Typewriter(Static):
         if "[" in text or "]" in text:
             # If there are brackets in the text, disable markup to avoid conflicts
             self._use_markup = False
+
+        # Call parent constructor with proper parameters
+        super().__init__(
+            content,
+            expand=expand,
+            shrink=shrink,
+            markup=markup,
+            name=name,
+            id=id,
+            classes=classes,
+            disabled=disabled,
+        )
 
     def compose(self) -> ComposeResult:
         self._static = Static(markup=self._use_markup)

--- a/src/glados/tui.py
+++ b/src/glados/tui.py
@@ -2,7 +2,7 @@ from collections.abc import Iterator
 from pathlib import Path
 import random
 import sys
-from typing import ClassVar
+from typing import Any, ClassVar, cast
 
 from loguru import logger
 from rich.text import Text
@@ -195,16 +195,16 @@ class SplashScreen(Screen[None]):
 
         This method is triggered when a key is pressed during the splash screen display.
         All keybinds which are active in the main app are active here automatically
-        so, for example, ctrl-q will terminate the app.
-        Any other key will dismiss the splash screen.
+        so, for example, ctrl-q will terminate the app. They do not need to be handled.
+        Any other key will start the GlaDOS engine and then dismiss the splash screen.
 
         Args:
             event (events.Key): The key event that was triggered.
         """
-
-        if self.app.glados_engine_instance:
-            self.app.glados_engine_instance.play_announcement()
-            self.app.start_glados()
+        app = cast(GladosUI, self.app)  # mypy gets confused about app's type
+        if app.glados_engine_instance:
+            app.glados_engine_instance.play_announcement()
+            app.start_glados()
             self.dismiss()
 
 


### PR DESCRIPTION
I *think* this is all that is necessary.

Fixing startup was easy - the engine is now started using `run`. On shutdown the TUI was waiting for the engine in the worker thread to stop and return, but following the refactor it never returns.  The fix is:
- When the TUI quits, it shuts down the UI, and notifies the worker thread that it should stop. There is no longer any need for the TUI to await the termination of the worker thread.  The worker thread handles system exit cleanly, so there is no need for the error checking code

Closes #144 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Simplified quitting the application by delegating exit control to main keybindings and removing complex shutdown steps.
  - Streamlined startup and shutdown processes for improved app responsiveness and reliability.
  - Improved widget initialization with clearer and more explicit parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->