### PR TITLE
download model files in parallel, general fixups

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,8 @@ dependencies = [
     "numba>=0.61.0",
     "soundfile>=0.13.0",
     "pydantic>=2.10.6",
+    "httpx>=0.28.1",
+    "rich>=14.0.0",
 ]
 
 [project.optional-dependencies]

--- a/src/glados/cli.py
+++ b/src/glados/cli.py
@@ -1,8 +1,12 @@
 import argparse
-import hashlib
+import asyncio
+from hashlib import sha256
 from pathlib import Path
+import sys
 
-import requests
+import httpx
+from rich import print as rprint
+from rich.progress import BarColumn, DownloadColumn, Progress, TextColumn
 import sounddevice as sd  # type: ignore
 
 from .core.engine import Glados, GladosConfig
@@ -10,184 +14,150 @@ from .TTS import tts_glados
 from .utils import spoken_text_converter as stc
 from .utils.resources import resource_path
 
+# Type aliases for clarity
+type FileHash = str
+type FileURL = str
+type FileName = str
+
 DEFAULT_CONFIG = resource_path("configs/glados_config.yaml")
 
-MODEL_CHECKSUMS = {
-    "models/ASR/nemo-parakeet_tdt_ctc_110m.onnx": "313705ff6f897696ddbe0d92b5ffadad7429a47d2ddeef370e6f59248b1e8fb5",
-    "models/ASR/parakeet-tdt-0.6b-v2_encoder.onnx": "f133a92186e63c7d4ab5b395a8e45d49f4a7a84a1d80b66f494e8205dfd57b63",
-    "models/ASR/parakeet-tdt-0.6b-v2_decoder.onnx": "415b14f965b2eb9d4b0b8517f0a1bf44a014351dd43a09c3a04d26a41c877951",
-    "models/ASR/parakeet-tdt-0.6b-v2_joiner.onnx": "846929b668a94462f21be25c7b5a2d83526e0b92a8306f21d8e336fc98177976",
-    "models/ASR/silero_vad_v5.onnx": "6b99cbfd39246b6706f98ec13c7c50c6b299181f2474fa05cbc8046acc274396",
-    "models/TTS/glados.onnx": "17ea16dd18e1bac343090b8589042b4052f1e5456d42cad8842a4f110de25095",
-    "models/TTS/kokoro-v1.0.fp16.onnx": "c1610a859f3bdea01107e73e50100685af38fff88f5cd8e5c56df109ec880204",
-    "models/TTS/kokoro-voices-v1.0.bin": "c5adf5cc911e03b76fa5025c1c225b141310d0c4a721d6ed6e96e73309d0fd88",
-    "models/TTS/phomenizer_en.onnx": "b64dbbeca8b350927a0b6ca5c4642e0230173034abd0b5bb72c07680d700c5a0",
+# Details of all the models.  Each key is the file path where the model should be saved
+MODEL_DETAILS: dict[FileName, dict[FileURL, FileHash]] = {
+    "models/ASR/nemo-parakeet_tdt_ctc_110m.onnx": {
+        "url": "https://github.com/dnhkng/GlaDOS/releases/download/0.1/nemo-parakeet_tdt_ctc_110m.onnx",
+        "checksum": "313705ff6f897696ddbe0d92b5ffadad7429a47d2ddeef370e6f59248b1e8fb5",
+    },
+    "models/ASR/parakeet-tdt-0.6b-v2_encoder.onnx": {
+        "url": "https://github.com/dnhkng/GlaDOS/releases/download/0.1/parakeet-tdt-0.6b-v2_encoder.onnx",
+        "checksum": "f133a92186e63c7d4ab5b395a8e45d49f4a7a84a1d80b66f494e8205dfd57b63",
+    },
+    "models/ASR/parakeet-tdt-0.6b-v2_decoder.onnx": {
+        "url": "https://github.com/dnhkng/GlaDOS/releases/download/0.1/parakeet-tdt-0.6b-v2_decoder.onnx",
+        "checksum": "415b14f965b2eb9d4b0b8517f0a1bf44a014351dd43a09c3a04d26a41c877951",
+    },
+    "models/ASR/parakeet-tdt-0.6b-v2_joiner.onnx": {
+        "url": "https://github.com/dnhkng/GlaDOS/releases/download/0.1/parakeet-tdt-0.6b-v2_joiner.onnx",
+        "checksum": "846929b668a94462f21be25c7b5a2d83526e0b92a8306f21d8e336fc98177976",
+    },
+    "models/ASR/silero_vad_v5.onnx": {
+        "url": "https://github.com/dnhkng/GlaDOS/releases/download/0.1/silero_vad_v5.onnx",
+        "checksum": "6b99cbfd39246b6706f98ec13c7c50c6b299181f2474fa05cbc8046acc274396",
+    },
+    "models/TTS/glados.onnx": {
+        "url": "https://github.com/dnhkng/GlaDOS/releases/download/0.1/glados.onnx",
+        "checksum": "17ea16dd18e1bac343090b8589042b4052f1e5456d42cad8842a4f110de25095",
+    },
+    "models/TTS/kokoro-v1.0.fp16.onnx": {
+        "url": "https://github.com/dnhkng/GLaDOS/releases/download/0.1/kokoro-v1.0.fp16.onnx",
+        "checksum": "c1610a859f3bdea01107e73e50100685af38fff88f5cd8e5c56df109ec880204",
+    },
+    "models/TTS/kokoro-voices-v1.0.bin": {
+        "url": "https://github.com/dnhkng/GLaDOS/releases/download/0.1/kokoro-voices-v1.0.bin",
+        "checksum": "c5adf5cc911e03b76fa5025c1c225b141310d0c4a721d6ed6e96e73309d0fd88",
+    },
+    "models/TTS/phomenizer_en.onnx": {
+        "url": "https://github.com/dnhkng/GlaDOS/releases/download/0.1/phomenizer_en.onnx",
+        "checksum": "b64dbbeca8b350927a0b6ca5c4642e0230173034abd0b5bb72c07680d700c5a0",
+    },
 }
 
-MODEL_URLS = {
-    "models/ASR/nemo-parakeet_tdt_ctc_110m.onnx": "https://github.com/dnhkng/GlaDOS/releases/download/0.1/nemo-parakeet_tdt_ctc_110m.onnx",
-    "models/ASR/parakeet-tdt-0.6b-v2_encoder.onnx": "https://github.com/dnhkng/GlaDOS/releases/download/0.1/parakeet-tdt-0.6b-v2_encoder.onnx",
-    "models/ASR/parakeet-tdt-0.6b-v2_decoder.onnx": "https://github.com/dnhkng/GlaDOS/releases/download/0.1/parakeet-tdt-0.6b-v2_decoder.onnx",
-    "models/ASR/parakeet-tdt-0.6b-v2_joiner.onnx": "https://github.com/dnhkng/GlaDOS/releases/download/0.1/parakeet-tdt-0.6b-v2_joiner.onnx",
-    "models/ASR/silero_vad_v5.onnx": "https://github.com/dnhkng/GlaDOS/releases/download/0.1/silero_vad_v5.onnx",
-    "models/TTS/glados.onnx": "https://github.com/dnhkng/GlaDOS/releases/download/0.1/glados.onnx",
-    "models/TTS/kokoro-v1.0.fp16.onnx": "https://github.com/dnhkng/GLaDOS/releases/download/0.1/kokoro-v1.0.fp16.onnx",
-    "models/TTS/kokoro-voices-v1.0.bin": "https://github.com/dnhkng/GLaDOS/releases/download/0.1/kokoro-voices-v1.0.bin",
-    "models/TTS/phomenizer_en.onnx": "https://github.com/dnhkng/GlaDOS/releases/download/0.1/phomenizer_en.onnx",
-}
 
-
-assert MODEL_CHECKSUMS.keys() == MODEL_URLS.keys()
-
-
-def verify_checksums() -> dict[str, bool]:
+async def download_with_progress(
+    client: httpx.AsyncClient,
+    url: str,
+    file_path: Path,
+    expected_checksum: str,
+    progress: Progress,
+) -> bool:
     """
-    Verify the integrity of model files by comparing their SHA-256 checksums against expected values.
-
-    This function checks each model file specified in MODEL_CHECKSUMS to ensure it exists
-    and has the correct checksum. Files that are missing or have incorrect checksums are
-    marked as invalid.
-
-    Parameters:
-        None
+    Download a single file with progress tracking and SHA-256 checksum verification.
 
     Returns:
-        dict[str, bool]: A dictionary where keys are model file paths and values are
-                         boolean indicators of checksum validity (True if valid, False if
-                         missing or checksum mismatch)
-
-    Example:
-        >>> verify_checksums()
-        {
-            'models/tts_model.pth': True,
-            'models/asr_model.bin': False
-        }
+        bool: True if download and verification succeeded, False otherwise
     """
-    results = {}
-    for path, expected in MODEL_CHECKSUMS.items():
-        path_to_model = resource_path(path)
-        if not path_to_model.exists():
-            results[path] = False
-            continue
+    task_id = progress.add_task(f"Downloading {file_path}", status="")
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    hash_sha256 = sha256()
 
-        sha = hashlib.sha256()
-        sha.update(path_to_model.read_bytes())
-        results[path] = sha.hexdigest() == expected
+    try:
+        async with client.stream("GET", url) as response:
+            response.raise_for_status()
 
-    return results
+            # Set total size for progress bar
+            total_size = int(response.headers.get("Content-Length", 0))
+            if total_size:
+                progress.update(task_id, total=total_size)
+
+            with file_path.open(mode="wb") as f:
+                async for chunk in response.aiter_bytes(32768):  # 32KB chunks
+                    f.write(chunk)
+                    # Update the hash as we go along, for speed
+                    hash_sha256.update(chunk)
+                    progress.advance(task_id, len(chunk))
+
+        # Verify checksum, and delete failed files
+        actual_checksum = hash_sha256.hexdigest()
+        if actual_checksum != expected_checksum:
+            progress.update(task_id, status="[bold red]Checksum failed")
+            Path.unlink(file_path)
+            return False
+        else:
+            progress.update(task_id, status="[bold green]OK")
+            return True
+
+    except Exception as e:
+        progress.update(task_id, status=f"[bold red]Error: {str(e)}")
+        return False
 
 
-def download_models() -> None:
-    """Download model files required for GLaDOS with robust error handling and progress tracking.
-
-    This function downloads the required model files from predefined URLs if they are missing
-    or have invalid checksums. It includes several reliability features:
-
-    Features:
-        - Progress tracking with percentage display
-        - Temporary file usage to prevent partial downloads
-        - SHA256 checksum verification during download
-        - Retry logic with exponential backoff (max 3 retries)
-        - Network timeout handling (30 seconds)
-        - Automatic cleanup of temporary files on failure
-        - Creation of parent directories if they don't exist
-
-    The function downloads the following models:
+async def download_models() -> int:
+    """
+    Main async controller for downloading all the specified models:
         - ASR model: nemo-parakeet_tdt_ctc_110m.onnx
         - VAD model: silero_vad.onnx
         - TTS model: glados.onnx
         - Phonemizer model: phomenizer_en.onnx
 
-    Raises:
-        requests.RequestException: If network errors occur during download
-        IOError: If file system operations fail
-        ValueError: If downloaded file has incorrect checksum
-        SystemExit: If any model download fails after max retries
-
-    Example:
-        >>> from glados.cli import download_models
-        >>> download_models()  # Downloads all required models with progress tracking
+    Returns:
+        int: Exit code (0 for success, 1 for failure)
     """
-    import sys
-    from time import sleep
-    from typing import BinaryIO
+    with Progress(
+        TextColumn("[grey50][progress.description]{task.description}"),
+        BarColumn(),
+        DownloadColumn(),
+        TextColumn("  {task.fields[status]}"),
+    ) as progress:
+        async with httpx.AsyncClient(follow_redirects=True) as client:
+            # Create a download task for each file
+            tasks = [
+                asyncio.create_task(
+                    download_with_progress(client, model_info["url"], Path(path), model_info["checksum"], progress)
+                )
+                for path, model_info in MODEL_DETAILS.items()
+            ]
+            results: list[bool] = await asyncio.gather(*tasks)
 
-    def calculate_sha256(file: BinaryIO) -> str:
-        """Calculate SHA256 hash of a file-like object."""
-        sha = hashlib.sha256()
-        file.seek(0)
-        for chunk in iter(lambda: file.read(8192), b""):
-            sha.update(chunk)
-        file.seek(0)
-        return sha.hexdigest()
+    if not all(results):
+        rprint("\n[bold red]Some files were not downloaded successfully")
+        return 1
+    rprint("\n[bold green]All files downloaded and verified successfully")
+    return 0
 
-    def download_with_progress(url: str, path: Path, expected_hash: str, max_retries: int = 3) -> None:
-        """Download a file with progress tracking and retry logic."""
-        retry_count = 0
-        temp_path = path.with_suffix(path.suffix + ".tmp")
 
-        while retry_count < max_retries:
-            try:
-                # Create parent directories if they don't exist
-                path.parent.mkdir(parents=True, exist_ok=True)
+def models_valid() -> bool:
+    """
+    Check the validity of all model files for the GLaDOS voice assistant.
 
-                # Start download with stream enabled
-                response = requests.get(url, stream=True, timeout=30)
-                response.raise_for_status()
-                total_size = int(response.headers.get("content-length", 0))
+    Verifies the integrity of model files by computing their checksums and comparing them against expected values.
 
-                # Open temporary file for writing
-                with open(temp_path, "wb") as f:
-                    if total_size == 0:
-                        print(f"\nDownloading {path.name} (size unknown)")
-                    else:
-                        print(f"\nDownloading {path.name} ({total_size / 1024 / 1024:.1f} MB)")
-
-                    downloaded_size = 0
-                    for chunk in response.iter_content(chunk_size=8192):
-                        if chunk:
-                            f.write(chunk)
-                            downloaded_size += len(chunk)
-                            if total_size > 0:
-                                progress = (downloaded_size / total_size) * 100
-                                sys.stdout.write(f"\rProgress: {progress:.1f}%")
-                                sys.stdout.flush()
-
-                # Verify checksum
-                with open(temp_path, "rb") as f:
-                    if calculate_sha256(f) != expected_hash:
-                        raise ValueError("Downloaded file has incorrect checksum")
-
-                # Rename temporary file to final path
-                if path.exists():
-                    path.unlink()
-                temp_path.rename(path)
-                print(f"\nSuccessfully downloaded {path.name}")
-                return
-
-            except (OSError, requests.RequestException, ValueError) as e:
-                retry_count += 1
-                if temp_path.exists():
-                    temp_path.unlink()
-
-                if retry_count < max_retries:
-                    wait_time = 2**retry_count  # Exponential backoff
-                    print(f"\nError downloading {path.name}: {e!s}")
-                    print(f"Retrying in {wait_time} seconds... (Attempt {retry_count + 1}/{max_retries})")
-                    sleep(wait_time)
-                else:
-                    print(f"\nFailed to download {path.name} after {max_retries} attempts: {e!s}")
-                    raise
-
-    # Download each model file
-    checksums = verify_checksums()
-    for path, is_valid in checksums.items():
-        if not is_valid:
-            try:
-                download_with_progress(MODEL_URLS[path], Path(path), MODEL_CHECKSUMS[path])
-            except Exception as e:
-                print(f"Error: Failed to download {path}: {e!s}")
-                sys.exit(1)
+    Returns:
+        bool: True if all model files are valid and present, False otherwise.
+    """
+    for path, model_info in MODEL_DETAILS.items():
+        file_path = Path(path)
+        if not (file_path.exists() and sha256(file_path.read_bytes()).hexdigest() == model_info["checksum"]):
+            return False
+    return True
 
 
 def say(text: str, config_path: str | Path = "glados_config.yaml") -> None:
@@ -264,24 +234,7 @@ def tui(config_path: str | Path = "glados_config.yaml") -> None:
         sys.exit()
 
 
-def models_valid() -> bool:
-    """
-    Check the validity of all model files for the GLaDOS voice assistant.
-
-    Verifies the integrity of model files by computing their checksums and comparing them against expected values.
-
-    Returns:
-        bool: True if all model files are valid and present, False otherwise. When False, prints a message
-              instructing the user to download the required model files.
-    """
-    results = verify_checksums()
-    if not all(results.values()):
-        print("Some model files are missing or invalid. Please run 'uv run glados download'")
-        return False
-    return True
-
-
-def main() -> None:
+def main() -> int:
     """
     Command-line interface (CLI) entry point for the GLaDOS voice assistant.
 
@@ -331,11 +284,11 @@ def main() -> None:
     args = parser.parse_args()
 
     if args.command == "download":
-        download_models()
+        return asyncio.run(download_models())
     else:
-        if models_valid() is False:
-            print("Model files are invalid or missing. Please run 'uv run glados download'")
-            return
+        if not models_valid():
+            print("Some model files are invalid or missing. Please run 'uv run glados download'")
+            return 0
         if args.command == "say":
             say(args.text, args.config)
         elif args.command == "start":
@@ -345,7 +298,8 @@ def main() -> None:
         else:
             # Default to start if no command specified
             start(DEFAULT_CONFIG)
+        return 0
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/src/glados/cli.py
+++ b/src/glados/cli.py
@@ -288,7 +288,7 @@ def main() -> int:
     else:
         if not models_valid():
             print("Some model files are invalid or missing. Please run 'uv run glados download'")
-            return 0
+            return 1
         if args.command == "say":
             say(args.text, args.config)
         elif args.command == "start":


### PR DESCRIPTION
I started this by parallelising model downloads (using `httpx`  - already a dependency). Then added pretty progress bars using `rich` (ditto). Then some general fixups (using pathlib consistently, regularising return values etc).  The changes look fairly extensive, but hopefully not too bad!

* download model files in parallel using httpx
* use rich progress bar for colour
* remove dead code and update old code to more recent python

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced model file downloads with asynchronous transfers and real-time progress bars in the CLI.
  * Improved console output with colored status messages.

* **Refactor**
  * Streamlined model file verification and download logic for better performance and reliability.

* **Chores**
  * Added new dependencies to support asynchronous downloads and rich terminal output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->