### PR TITLE
Fix audio error from OutputStream

### DIFF
--- a/src/glados/audio_io/sounddevice_io.py
+++ b/src/glados/audio_io/sounddevice_io.py
@@ -170,16 +170,15 @@ class SoundDeviceAudioIO:
 
         def stream_callback(
             outdata: NDArray[np.float32], frames: int, time: dict[str, Any], status: sd.CallbackFlags
-        ) -> tuple[NDArray[np.float32], sd.CallbackStop | None]:
+        ) -> None:
             nonlocal progress, interrupted
             progress += frames
             if self._is_playing is False:
                 interrupted = True
                 completion_event.set()
-                return outdata, sd.CallbackStop
             if progress >= total_samples:
                 completion_event.set()
-            return outdata, None
+            outdata.fill(0)
 
         try:
             logger.debug(f"Using sample rate: {sample_rate} Hz, total samples: {total_samples}")


### PR DESCRIPTION
OutputStream audio contained random noise, due to improper stream callback handling.
The [sounddevice docs](https://python-sounddevice.readthedocs.io/en/0.5.1/api/streams.html#streams-using-numpy-arrays)  indicate the `callback` must have a `None` return signature and that
```
If no data is available, the buffer should be filled with zeros (e.g. by using outdata.fill(0))
```
After removing the unnecessary returns (formatted for `PyAudio` and not `sounddevice` `OutputStream` callbacks), updating the callback signature and filling the buffer with zeros, this fixed my issue.

Note: This may be pulse-specific as that is set as my `default_device` running Arch linux.

Stream output before change ( :warning:  horrible noise):

https://github.com/user-attachments/assets/ef6231e8-a09b-4a97-9bb7-ded64bd939be


Stream output after change:

https://github.com/user-attachments/assets/d0fa46f2-fce2-46e7-ab13-41804e9ed39b

