### PR TITLE
Update Synthesizer naming in tts.py

### DIFF
--- a/src/glados/api/tts.py
+++ b/src/glados/api/tts.py
@@ -14,7 +14,7 @@ def write_glados_audio_file(f: str | io.BytesIO, text: str, *, format: str) -> N
         text: Text to convert to speech
         format: Audio format (e.g., "mp3", "wav", "ogg")
     """
-    glados_tts = tts_glados.Synthesizer()
+    glados_tts = tts_glados.SpeechSynthesizer()
     converter = spoken_text_converter.SpokenTextConverter()
     converted_text = converter.text_to_spoken(text)
     audio = glados_tts.generate_speech_audio(converted_text)


### PR DESCRIPTION
Running this as a server has an issue because the naming isn't correctly written as SpeechSynthesizer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internally updated the GLaDOS text-to-speech synthesizer without altering user-facing behavior.
  * Speech generation flow, configuration, and audio output (format and sample rate) remain unchanged, preserving existing integrations.
  * No changes to public APIs or error handling; apps and scripts continue to work as before. No action required.
  * Compatibility and performance expectations are unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->