### PR TITLE
Move observability shortcut to Ctrl+O

### DIFF
--- a/src/glados/tui.py
+++ b/src/glados/tui.py
@@ -352,7 +352,7 @@ class GladosUI(App[None]):
             key_display="?",
         ),
         Binding(key="slash", action="command", description="Command", key_display="/"),
-        Binding(key="o", action="observability", description="Observability"),
+        Binding(key="ctrl+o", action="observability", description="Observability", key_display="Ctrl+O"),
     ]
     CSS_PATH = "glados_ui/glados.tcss"
 


### PR DESCRIPTION
## Summary
- change observability hotkey from o to Ctrl+O to avoid interfering with text input

## Testing
- uv run --extra dev --extra api pytest


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Modified keyboard shortcut for accessing the Observability screen from "o" to "Ctrl+O". The updated key combination is now displayed as "Ctrl+O" throughout the interface.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->