### PR TITLE
Expand slash commands and knowledge store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -165,3 +165,6 @@ cython_debug/
 *.gguf
 *.onnx
 *.nemo
+
+# Local knowledge store
+data/knowledge.json

--- a/README.md
+++ b/README.md
@@ -111,7 +111,15 @@ Install the PortAudio library, if you don't yet have it installed:
 
         uv run glados start --input-mode both
 
-    In text or TUI mode, type `/help` to see available slash commands (e.g. `/asr off`).
+    In text or TUI mode, type `/help` to see available slash commands. Highlights:
+
+        /status
+        /asr on|off|toggle
+        /observe
+        /slots
+        /minds
+        /vision
+        /knowledge add|list|set|delete|clear
 
 ## Speech Generation
 You can also get her to say something with:

--- a/src/glados/core/knowledge_store.py
+++ b/src/glados/core/knowledge_store.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+from pathlib import Path
+import threading
+import time
+
+from loguru import logger
+
+
+@dataclass(frozen=True)
+class KnowledgeEntry:
+    entry_id: int
+    text: str
+    created_at: float
+    updated_at: float
+
+
+class KnowledgeStore:
+    def __init__(self, path: Path) -> None:
+        self._path = path
+        self._lock = threading.Lock()
+
+    def list_entries(self) -> list[KnowledgeEntry]:
+        with self._lock:
+            return self._load_entries()
+
+    def add(self, text: str) -> KnowledgeEntry:
+        with self._lock:
+            entries = self._load_entries()
+            next_id = max((entry.entry_id for entry in entries), default=0) + 1
+            now = time.time()
+            entry = KnowledgeEntry(entry_id=next_id, text=text, created_at=now, updated_at=now)
+            entries.append(entry)
+            self._write_entries(entries)
+            return entry
+
+    def update(self, entry_id: int, text: str) -> KnowledgeEntry | None:
+        with self._lock:
+            entries = self._load_entries()
+            updated = None
+            now = time.time()
+            new_entries: list[KnowledgeEntry] = []
+            for entry in entries:
+                if entry.entry_id == entry_id:
+                    updated = KnowledgeEntry(
+                        entry_id=entry.entry_id,
+                        text=text,
+                        created_at=entry.created_at,
+                        updated_at=now,
+                    )
+                    new_entries.append(updated)
+                else:
+                    new_entries.append(entry)
+            if updated:
+                self._write_entries(new_entries)
+            return updated
+
+    def delete(self, entry_id: int) -> bool:
+        with self._lock:
+            entries = self._load_entries()
+            new_entries = [entry for entry in entries if entry.entry_id != entry_id]
+            if len(new_entries) == len(entries):
+                return False
+            self._write_entries(new_entries)
+            return True
+
+    def clear(self) -> int:
+        with self._lock:
+            entries = self._load_entries()
+            if not entries:
+                return 0
+            self._write_entries([])
+            return len(entries)
+
+    def _load_entries(self) -> list[KnowledgeEntry]:
+        if not self._path.exists():
+            return []
+        try:
+            data = json.loads(self._path.read_text(encoding="utf-8"))
+        except Exception as exc:
+            logger.warning("KnowledgeStore: failed to read %s: %s", self._path, exc)
+            return []
+
+        if isinstance(data, dict):
+            items = data.get("entries", [])
+        else:
+            items = data
+
+        entries: list[KnowledgeEntry] = []
+        for item in items:
+            try:
+                entries.append(
+                    KnowledgeEntry(
+                        entry_id=int(item["entry_id"]),
+                        text=str(item["text"]),
+                        created_at=float(item.get("created_at", 0.0)),
+                        updated_at=float(item.get("updated_at", 0.0)),
+                    )
+                )
+            except Exception:
+                continue
+        return entries
+
+    def _write_entries(self, entries: list[KnowledgeEntry]) -> None:
+        payload = {
+            "entries": [
+                {
+                    "entry_id": entry.entry_id,
+                    "text": entry.text,
+                    "created_at": entry.created_at,
+                    "updated_at": entry.updated_at,
+                }
+                for entry in entries
+            ]
+        }
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        self._path.write_text(json.dumps(payload, indent=2), encoding="utf-8")

--- a/src/glados/tui.py
+++ b/src/glados/tui.py
@@ -352,7 +352,6 @@ class GladosUI(App[None]):
             key_display="?",
         ),
         Binding(key="slash", action="command", description="Command", key_display="/"),
-        Binding(key="ctrl+o", action="observability", description="Observability", key_display="Ctrl+O"),
     ]
     CSS_PATH = "glados_ui/glados.tcss"
 


### PR DESCRIPTION
## Summary
- add command registry and new commands for slots/minds/vision/config
- add local knowledge store with /knowledge add|list|set|delete|clear
- remove observability hotkey to rely on /observe

## Testing
- uv run --extra dev --extra api pytest


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added knowledge management system with commands to add, list, update, delete, and clear local knowledge entries.
  * Implemented improved command handling with expanded command surface including status, audio controls, observation, slots, minds, vision, and config commands.

* **Documentation**
  * Updated README with highlights of available slash commands.

* **Changes**
  * Removed Ctrl+O keyboard shortcut for observability screen.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->