### PR TITLE
Harden container security by running as non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,10 +8,19 @@ RUN apt-get update && apt-get install -y \
 
 RUN pip install uv
 
+# Create a non-root user for security
+RUN useradd -m -u 1000 glados
+
 WORKDIR /app
-COPY pyproject.toml README.md ./
-COPY models/ ./models/
-COPY src/ ./src/
+
+# Set ownership of /app so glados can create .venv
+RUN chown glados:glados /app
+
+COPY --chown=glados:glados pyproject.toml README.md ./
+COPY --chown=glados:glados models/ ./models/
+COPY --chown=glados:glados src/ ./src/
+
+USER glados
 
 RUN uv sync --extra api --extra cpu --no-dev \
   && uv run glados download


### PR DESCRIPTION
Implementing security best practices by switching the Docker container to a non-root user. 

Currently, the processes within the container run as `root` by default. While convenient for development, this increases the risk of container breakout and privilege escalation if the application (Litestar) or its dependencies have vulnerabilities. 

I've updated the `Dockerfile` to:
- Create a dedicated `glados` user.
- Set appropriate ownership for the application directory during the copy process.
- Switch to the `glados` user before running the application.

This change adheres to the principle of least privilege without affecting the application's core functionality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Build now runs as a non-root user to improve security.
  * File copy operations preserve ownership so files and directories are owned correctly after build.
  * Explicit ownership of the application directory ensures the non-root user can create the virtual environment during image build.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->