### PR TITLE
Fix: Install critical buildtime deps in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,8 @@ FROM python:3.12-slim
 RUN apt-get update && apt-get install -y \
   libportaudio2 \
   portaudio19-dev \
+  libgl1 \
+  libglib2.0-0 \
   git \
   && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Added libraries libgl1 and libglib2.0-0 to Dockerfile.  These are required to complete the build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated system library dependencies in the container configuration to improve application compatibility and stability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->