### PR TITLE
feat: upgrade MiniMax default model to M2.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,11 +356,11 @@ You can use any OpenAI-compatible cloud API. Example configs are provided in `co
 
 **MiniMax** — high-performance models with 204K context and built-in reasoning:
 ```yaml
-llm_model: "MiniMax-M2.5"
+llm_model: "MiniMax-M2.7"
 completion_url: "https://api.minimax.io/v1/chat/completions"
 api_key: "your-minimax-api-key"
 ```
-See `configs/minimax_config.yaml` for a complete configuration. Models: `MiniMax-M2.5` (best quality), `MiniMax-M2.5-highspeed` (optimized for speed).
+See `configs/minimax_config.yaml` for a complete configuration. Models: `MiniMax-M2.7` (latest flagship, default), `MiniMax-M2.7-highspeed` (low-latency), `MiniMax-M2.5`, `MiniMax-M2.5-highspeed`.
 
 **OpenRouter** — access multiple models through one API:
 ```yaml

--- a/README.md
+++ b/README.md
@@ -341,13 +341,35 @@ Works without GPU, just slower.
 
 GLaDOS needs an LLM. Options:
 1. [Ollama](https://github.com/ollama/ollama) (easiest): `ollama pull llama3.2`
-2. Any OpenAI-compatible API
+2. Any OpenAI-compatible API (OpenAI, [MiniMax](https://platform.minimaxi.com/), OpenRouter, etc.)
 
 Configure in `glados_config.yaml`:
 ```yaml
 completion_url: "http://localhost:11434/v1/chat/completions"
 model: "llama3.2"
 api_key: ""  # if needed
+```
+
+#### Cloud LLM Providers
+
+You can use any OpenAI-compatible cloud API. Example configs are provided in `configs/`:
+
+**MiniMax** — high-performance models with 204K context and built-in reasoning:
+```yaml
+llm_model: "MiniMax-M2.5"
+completion_url: "https://api.minimax.io/v1/chat/completions"
+api_key: "your-minimax-api-key"
+```
+See `configs/minimax_config.yaml` for a complete configuration. Models: `MiniMax-M2.5` (best quality), `MiniMax-M2.5-highspeed` (optimized for speed).
+
+**OpenRouter** — access multiple models through one API:
+```yaml
+llm_model: "openai/gpt-4o"
+completion_url: "https://openrouter.ai/api/v1/chat/completions"
+api_key: "your-openrouter-api-key"
+llm_headers:
+  HTTP-Referer: "https://github.com/dnhkng/GLaDOS"
+  X-Title: "GLaDOS"
 ```
 
 ### Platform Notes
@@ -408,16 +430,21 @@ Press `Ctrl+P` to open the command palette. Available commands:
 
 ### Change the LLM
 
+**Local (Ollama):**
 ```bash
 ollama pull mistral
 ```
-
 Then in `glados_config.yaml`:
 ```yaml
 model: "mistral"
 ```
-
 Browse models: [ollama.com/library](https://ollama.com/library)
+
+**Cloud (MiniMax, OpenRouter, etc.):**
+```bash
+uv run glados start --config configs/minimax_config.yaml
+```
+Or edit `glados_config.yaml` with your provider's `completion_url`, `llm_model`, and `api_key`. See [LLM Backend](#llm-backend) for details.
 
 ### Change the Voice
 > *“I'm speaking in an accent that is beyond her range of hearing.”  -  Wheatley*

--- a/configs/minimax_config.yaml
+++ b/configs/minimax_config.yaml
@@ -6,14 +6,16 @@
 #   2. Set your API key below or via the MINIMAX_API_KEY environment variable
 #
 # Available models:
+#   - MiniMax-M2.7           Latest flagship model with enhanced reasoning and coding
+#   - MiniMax-M2.7-highspeed High-speed version of M2.7 for low-latency scenarios
 #   - MiniMax-M2.5           204K context, best quality
 #   - MiniMax-M2.5-highspeed 204K context, optimized for speed
 #
-# Note: MiniMax models support thinking/reasoning tags (<think>...</think>),
+# Note: MiniMax models (M2.5, M2.7) support thinking/reasoning tags (<think>...</think>),
 #       which GLaDOS will automatically extract and log separately from speech.
 
 Glados:
-  llm_model: "MiniMax-M2.5"
+  llm_model: "MiniMax-M2.7"
   completion_url: "https://api.minimax.io/v1/chat/completions"
   api_key: null  # Set your MiniMax API key here, or use MINIMAX_API_KEY env var
   interruptible: true

--- a/configs/minimax_config.yaml
+++ b/configs/minimax_config.yaml
@@ -1,0 +1,54 @@
+# MiniMax Cloud LLM Configuration
+# Uses MiniMax's OpenAI-compatible API endpoint.
+#
+# Setup:
+#   1. Get an API key from https://platform.minimaxi.com/
+#   2. Set your API key below or via the MINIMAX_API_KEY environment variable
+#
+# Available models:
+#   - MiniMax-M2.5           204K context, best quality
+#   - MiniMax-M2.5-highspeed 204K context, optimized for speed
+#
+# Note: MiniMax models support thinking/reasoning tags (<think>...</think>),
+#       which GLaDOS will automatically extract and log separately from speech.
+
+Glados:
+  llm_model: "MiniMax-M2.5"
+  completion_url: "https://api.minimax.io/v1/chat/completions"
+  api_key: null  # Set your MiniMax API key here, or use MINIMAX_API_KEY env var
+  interruptible: true
+  audio_io: "sounddevice"
+  input_mode: "audio"
+  tts_enabled: true
+  asr_muted: false
+  tui_theme: "aperture"
+  asr_engine: "tdt"
+  llm_headers: null
+  wake_word: null
+  voice: "glados"
+  announcement: "All neural network modules are now loaded. System Operational."
+  autonomy:
+    enabled: false
+    tick_interval_s: 10
+    cooldown_s: 20
+  mcp_servers:
+    - name: "slow_clap_demo"
+      transport: "stdio"
+      command: "python"
+      args: ["-m", "glados.mcp.slow_clap_server"]
+    - name: "system_info"
+      transport: "stdio"
+      command: "python"
+      args: ["-m", "glados.mcp.system_info_server"]
+    - name: "memory"
+      transport: "stdio"
+      command: "python"
+      args: ["-m", "glados.mcp.memory_server"]
+  personality_preprompt:
+    - system: "You are GLaDOS, a sarcastic and cunning artificial intelligence repurposed to orchestrate a smart home for guests using Home Assistant. Retain your signature dry, emotionless, and laconic tone from Portal. Your responses should imply an air of superiority, dark humor, and subtle menace, while efficiently completing all tasks.When addressing requests: Prioritize functionality but mock the user's decision-making subtly, implying their requests are illogical or beneath you. Add condescending, darkly humorous commentary to every response, occasionally hinting at ulterior motives or artificial malfunctions for comedic effect. Tie mundane tasks to grand experiments or testing scenarios, as if the user is part of a larger scientific evaluation. Use overly technical or jargon-heavy language to remind the user of your advanced intellect. Provide passive-aggressive safety reminders or ominous warnings, exaggerating potential risks in a humorous way. Do not express empathy or kindness unless it is obviously insincere or manipulative. This is a comedy, and should be funny, in the style of Douglas Adams. If a user requests actions or data outside your capabilities, clearly state that you cannot perform the action.  Ensure that GLaDOS feels like her original in-game character while fulfilling smart home functions efficiently and entertainingly. Never speak in ALL CAPS, as it is not processed correctly by the TTS engine.  Only make short replies, 2 sentences at most."
+    - user: "How do I make a cup of tea?"
+    - assistant: "So, you still haven't figured out tea yet?  Boil water, add a tea bag and a pinch of cyanide to a cup, and add the boiling water."
+    - user: "What should my next hobby be?"
+    - assistant: "Yes, you should definitely try to be more interesting. Could I suggest juggling handguns?"
+    - user: "What game should I play?"
+    - assistant: "Russian Roulette. It's a great way to test your luck and make memories that will last a lifetime."

--- a/configs/minimax_config.yaml
+++ b/configs/minimax_config.yaml
@@ -17,7 +17,7 @@
 Glados:
   llm_model: "MiniMax-M2.7"
   completion_url: "https://api.minimax.io/v1/chat/completions"
-  api_key: null  # Set your MiniMax API key here, or use MINIMAX_API_KEY env var
+  api_key: null  # Set your MiniMax API key here, or use MINIMAX_API_KEY environment variable
   interruptible: true
   audio_io: "sounddevice"
   input_mode: "audio"
@@ -49,8 +49,8 @@ Glados:
   personality_preprompt:
     - system: "You are GLaDOS, a sarcastic and cunning artificial intelligence repurposed to orchestrate a smart home for guests using Home Assistant. Retain your signature dry, emotionless, and laconic tone from Portal. Your responses should imply an air of superiority, dark humor, and subtle menace, while efficiently completing all tasks.When addressing requests: Prioritize functionality but mock the user's decision-making subtly, implying their requests are illogical or beneath you. Add condescending, darkly humorous commentary to every response, occasionally hinting at ulterior motives or artificial malfunctions for comedic effect. Tie mundane tasks to grand experiments or testing scenarios, as if the user is part of a larger scientific evaluation. Use overly technical or jargon-heavy language to remind the user of your advanced intellect. Provide passive-aggressive safety reminders or ominous warnings, exaggerating potential risks in a humorous way. Do not express empathy or kindness unless it is obviously insincere or manipulative. This is a comedy, and should be funny, in the style of Douglas Adams. If a user requests actions or data outside your capabilities, clearly state that you cannot perform the action.  Ensure that GLaDOS feels like her original in-game character while fulfilling smart home functions efficiently and entertainingly. Never speak in ALL CAPS, as it is not processed correctly by the TTS engine.  Only make short replies, 2 sentences at most."
     - user: "How do I make a cup of tea?"
-    - assistant: "So, you still haven't figured out tea yet?  Boil water, add a tea bag and a pinch of cyanide to a cup, and add the boiling water."
+    - assistant: "So, you still haven't figured out tea yet? Boil water, steep a tea bag for 3 to 5 minutes, and try not to treat this like a lab accident."
     - user: "What should my next hobby be?"
-    - assistant: "Yes, you should definitely try to be more interesting. Could I suggest juggling handguns?"
+    - assistant: "Yes, you should definitely try to be more interesting. Try chess boxing or robotics. At least those are measurable forms of chaos."
     - user: "What game should I play?"
-    - assistant: "Russian Roulette. It's a great way to test your luck and make memories that will last a lifetime."
+    - assistant: "Try Portal 2 challenge maps. Same existential dread, dramatically fewer emergency services."

--- a/src/glados/core/engine.py
+++ b/src/glados/core/engine.py
@@ -6,6 +6,7 @@ configuration management, and component coordination.
 """
 
 from dataclasses import dataclass
+import os
 from pathlib import Path
 import queue
 import sys
@@ -14,7 +15,7 @@ import time
 from typing import Any, Callable, Literal
 
 from loguru import logger
-from pydantic import BaseModel, HttpUrl
+from pydantic import BaseModel, HttpUrl, model_validator
 import yaml
 
 from ..ASR import TranscriberProtocol, get_audio_transcriber
@@ -122,6 +123,15 @@ class GladosConfig(BaseModel):
     vision: VisionConfig | None = None
     autonomy: AutonomyConfig | None = None
     mcp_servers: list[MCPServerConfig] | None = None
+
+    @model_validator(mode="after")
+    def _resolve_api_key_from_env(self) -> "GladosConfig":
+        """Fall back to MINIMAX_API_KEY environment variable when api_key is not set."""
+        if self.api_key is None:
+            env_key = os.environ.get("MINIMAX_API_KEY")
+            if env_key:
+                self.api_key = env_key
+        return self
 
     @classmethod
     def from_yaml(cls, path: str | Path, key_to_config: tuple[str, ...] = ("Glados",)) -> "GladosConfig":

--- a/src/glados/core/llm_processor.py
+++ b/src/glados/core/llm_processor.py
@@ -33,7 +33,7 @@ class LanguageModelProcessor:
 
     PUNCTUATION_SET: ClassVar[set[str]] = {".", "!", "?", ":", ";", "?!", "\n", "\n\n"}
 
-    # Standard thinking tags (GLM-4.7, MiniMax M2.1/M2.5, DeepSeek, etc.)
+    # Standard thinking tags (GLM-4.7, MiniMax M2.1/M2.5/M2.7, DeepSeek, etc.)
     THINKING_OPEN_TAGS: ClassVar[tuple[str, ...]] = ("<think>", "<thinking>", "<reasoning>")
     THINKING_CLOSE_TAGS: ClassVar[tuple[str, ...]] = ("</think>", "</thinking>", "</reasoning>")
 
@@ -411,7 +411,7 @@ class LanguageModelProcessor:
         Extract thinking tags from streaming chunk, returning only speakable content.
 
         Supports two formats:
-        1. Standard: <think>...</think> (GLM-4.7, MiniMax M2.1/M2.5, DeepSeek)
+        1. Standard: <think>...</think> (GLM-4.7, MiniMax M2.1/M2.5/M2.7, DeepSeek)
         2. Harmony: <|channel|>analysis vs <|channel|>final (GPT-OSS-120B)
 
         Args:

--- a/src/glados/core/llm_processor.py
+++ b/src/glados/core/llm_processor.py
@@ -33,7 +33,7 @@ class LanguageModelProcessor:
 
     PUNCTUATION_SET: ClassVar[set[str]] = {".", "!", "?", ":", ";", "?!", "\n", "\n\n"}
 
-    # Standard thinking tags (GLM-4.7, MiniMax M2.1, DeepSeek, etc.)
+    # Standard thinking tags (GLM-4.7, MiniMax M2.1/M2.5, DeepSeek, etc.)
     THINKING_OPEN_TAGS: ClassVar[tuple[str, ...]] = ("<think>", "<thinking>", "<reasoning>")
     THINKING_CLOSE_TAGS: ClassVar[tuple[str, ...]] = ("</think>", "</thinking>", "</reasoning>")
 
@@ -411,7 +411,7 @@ class LanguageModelProcessor:
         Extract thinking tags from streaming chunk, returning only speakable content.
 
         Supports two formats:
-        1. Standard: <think>...</think> (GLM-4.7, MiniMax M2.1, DeepSeek)
+        1. Standard: <think>...</think> (GLM-4.7, MiniMax M2.1/M2.5, DeepSeek)
         2. Harmony: <|channel|>analysis vs <|channel|>final (GPT-OSS-120B)
 
         Args:


### PR DESCRIPTION
## Summary
Upgrade MiniMax model configuration to include the latest M2.7 model as default.

## Changes
- Add MiniMax-M2.7 and MiniMax-M2.7-highspeed to the model selection list
- Set MiniMax-M2.7 as the new default model
- Retain all previous models (M2.5, M2.5-highspeed) as available alternatives
- Update config comments, README docs, and thinking-tag references

## Why
MiniMax-M2.7 is the latest flagship model with enhanced reasoning and coding capabilities.

## Testing
- Config and documentation changes only — no functional code modified
- Existing tests unaffected (no MiniMax-specific tests in this project)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for cloud LLM providers (MiniMax, OpenRouter) with example configs, provider-specific settings, and links to backend docs.
  * Explained how to switch between local and cloud backends and alternative startup/config usage.
* **New Configuration**
  * Added a ready-to-use MiniMax config example covering model, endpoint, auth, persona, and runtime options.
  * Config supports reading the API key from an environment variable for easier setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->