### PR TITLE
fixed annoying error, when starting up the assistant with jobs = true

### DIFF
--- a/src/glados/core/engine.py
+++ b/src/glados/core/engine.py
@@ -710,7 +710,7 @@ class Glados:
         self.subagent_manager.register(emotion_agent)
         self._emotion_agent = emotion_agent  # Keep reference for event pushing
         # Wire emotion agent to autonomy loop for vision events
-        if self.autonomy_config.enabled and hasattr(self, "autonomy_loop"):
+        if self.autonomy_config.enabled and self.autonomy_loop:
             self.autonomy_loop.set_emotion_agent(emotion_agent)
 
         # Compaction agent - monitors conversation size and compacts when needed


### PR DESCRIPTION
because hassattr evaluated to true when self.autonomy_loop = None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced system stability by fixing a condition that ensures the emotion agent only connects to the autonomy loop when it is properly initialized and available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->