### PR TITLE
Vision mode: add support for IP cameras / camera specification by path

### DIFF
--- a/configs/glados_vision_config.yaml
+++ b/configs/glados_vision_config.yaml
@@ -27,7 +27,8 @@ Glados:
     #   token: "YOUR_LONG_LIVED_TOKEN"
   vision:
     # model_dir: null  # Path to FastVLM ONNX models. Uses default models/Vision if null
-    camera_index: 0
+    camera_spec: 0 # use first local camera (access by index)
+    # camera_spec: rtsp://192.168.0.1:5555/ # Use IP camera
     capture_interval_seconds: 5  # Seconds between captures
     resolution: 384  # Scene-change detection resolution
     scene_change_threshold: 0.05  # Min change to trigger inference (0=always, 1=never)

--- a/src/glados/vision/vision_config.py
+++ b/src/glados/vision/vision_config.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import Union
+from urllib.parse import urlsplit, urlunsplit
 
 from pydantic import BaseModel, Field, AliasChoices, NonNegativeInt, StrictStr
 
@@ -16,7 +17,7 @@ class VisionConfig(BaseModel):
     camera_spec: Union[NonNegativeInt, StrictStr] = Field(
         default=0,
         description="The specification of the camera to use for capturing images. Integers will be interpreted as a camera index, strings will be interpreted as a URI/filename. Use 0 if only one camera is connected.",
-        validation_alias=AliasChoices("camera_index", "camera_spec"),
+        validation_alias=AliasChoices("camera_spec", "camera_index"),
         union_mode='left_to_right',
     )
     capture_interval_seconds: float = Field(
@@ -41,3 +42,22 @@ class VisionConfig(BaseModel):
         le=512,
         description="Maximum tokens to generate in the background vision description.",
     )
+
+    def redacted_camera_spec_for_log(self) -> str:
+        """
+        Redact the camera spec for logging: censor credentials in a possible URL
+        Returns:
+            The redacted camera spec.
+        """
+        if isinstance(self.camera_spec, int):
+            return str(self.camera_spec)
+        elif isinstance(self.camera_spec, str):
+            # works for files as well
+            parts = urlsplit(self.camera_spec)
+            if parts.username or parts.password:
+                host = parts.hostname or ""
+                if parts.port:
+                    host = f"{host}:{parts.port}"
+                redacted_netloc = f"***:***@{host}"
+                return '"' + urlunsplit((parts.scheme, redacted_netloc, parts.path, parts.query, parts.fragment)) + '"'
+        return '"' + self.camera_spec + '"'

--- a/src/glados/vision/vision_config.py
+++ b/src/glados/vision/vision_config.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Union
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, AliasChoices, NonNegativeInt, StrictStr
 
 
 class VisionConfig(BaseModel):
@@ -12,10 +13,11 @@ class VisionConfig(BaseModel):
         default=None,
         description="Path to FastVLM ONNX model directory. Uses default if None.",
     )
-    camera_index: int = Field(
+    camera_spec: Union[NonNegativeInt, StrictStr] = Field(
         default=0,
-        ge=0,
-        description="The index of the camera to use for capturing images. Use 0 if only one camera is connected.",
+        description="The specification of the camera to use for capturing images. Integers will be interpreted as a camera index, strings will be interpreted as a URI/filename. Use 0 if only one camera is connected.",
+        validation_alias=AliasChoices("camera_index", "camera_spec"),
+        union_mode='left_to_right',
     )
     capture_interval_seconds: float = Field(
         default=5.0,

--- a/src/glados/vision/vision_processor.py
+++ b/src/glados/vision/vision_processor.py
@@ -129,16 +129,16 @@ class VisionProcessor:
         if self._capture is not None:
             self._capture.release()
 
-        self._capture = cv2.VideoCapture(self.config.camera_index)
+        self._capture = cv2.VideoCapture(self.config.camera_spec)
         if not self._capture.isOpened():
             logger.error(
-                "VisionProcessor: Unable to open camera index {}. Retrying in {:.1f}s.",
-                self.config.camera_index,
+                "VisionProcessor: Unable to open camera spec {}. Retrying in {:.1f}s.",
+                repr(self.config.camera_spec),
                 self.config.capture_interval_seconds,
             )
             return False
 
-        logger.success("VisionProcessor: Camera {} opened successfully.", self.config.camera_index)
+        logger.success("VisionProcessor: Camera {} opened successfully.", repr(self.config.camera_spec))
         return True
 
     def _grab_frame(self) -> NDArray[np.uint8] | None:
@@ -150,7 +150,7 @@ class VisionProcessor:
         assert self._capture is not None
         ret, frame = self._capture.read()
         if not ret or frame is None:
-            logger.warning("VisionProcessor: Failed to capture frame from camera {}.", self.config.camera_index)
+            logger.warning("VisionProcessor: Failed to capture frame from camera {}.", repr(self.config.camera_spec))
             return None
         return frame
 

--- a/src/glados/vision/vision_processor.py
+++ b/src/glados/vision/vision_processor.py
@@ -133,12 +133,12 @@ class VisionProcessor:
         if not self._capture.isOpened():
             logger.error(
                 "VisionProcessor: Unable to open camera spec {}. Retrying in {:.1f}s.",
-                repr(self.config.camera_spec),
+                self.config.redacted_camera_spec_for_log(),
                 self.config.capture_interval_seconds,
             )
             return False
 
-        logger.success("VisionProcessor: Camera {} opened successfully.", repr(self.config.camera_spec))
+        logger.success("VisionProcessor: Camera {} opened successfully.", self.config.redacted_camera_spec_for_log())
         return True
 
     def _grab_frame(self) -> NDArray[np.uint8] | None:
@@ -150,7 +150,7 @@ class VisionProcessor:
         assert self._capture is not None
         ret, frame = self._capture.read()
         if not ret or frame is None:
-            logger.warning("VisionProcessor: Failed to capture frame from camera {}.", repr(self.config.camera_spec))
+            logger.warning("VisionProcessor: Failed to capture frame from camera {}.", self.config.redacted_camera_spec_for_log())
             return None
         return frame
 


### PR DESCRIPTION
**Pull Request Summary – Flexible IP Camera Support**

This PR makes the vision configuration more flexible by letting you specify a camera either by its numeric index or by a full path/URL. It doesn’t add new features—OpenCV already handles these kinds of inputs—but it updates the configuration schema to make those options available.

* **Configuration Change** – `vision.camera_index` is replaced with `vision.camera_spec`. The old key is kept for backward compatibility.

* **Supported Formats** – `camera_spec` accepts either a non‑negative integer (camera index) or a string (file path, network stream URL, etc.).

* **Code Update** – All internal references to `vision.camera_index` have been switched to `vision.camera_spec`.

* **Documentation** – The example config file `configs/glados_vision_config.yaml` has been updated to illustrate the new `camera_spec` usage.

No new functionality is introduced; this change simply expands how the existing camera support can be configured.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for IP/network camera sources (RTSP/URI) in addition to local camera indices.

* **Improvements**
  * Camera setting now accepts either an index or a URI for greater flexibility.
  * Backward compatibility preserved—existing index-based configs continue to work.
  * Camera source info in logs is now redacted to avoid exposing embedded credentials.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->