### PR TITLE
fix: stop audio stream when input_mode is text in TUI (fixes #188)

### DIFF
--- a/src/glados/core/engine.py
+++ b/src/glados/core/engine.py
@@ -107,7 +107,7 @@ class GladosConfig(BaseModel):
     api_key: str | None
     interruptible: bool
     audio_io: str
-    input_mode: Literal["audio", "text", "both"] = "audio"
+    input_mode: Literal["audio", "text", "both", "none"] = "audio"
     tts_enabled: bool = True
     asr_muted: bool = False
     asr_engine: str
@@ -198,7 +198,7 @@ class Glados:
         vision_config: VisionConfig | None = None,
         autonomy_config: AutonomyConfig | None = None,
         mcp_servers: list[MCPServerConfig] | None = None,
-        input_mode: Literal["audio", "text", "both"] = "audio",
+        input_mode: Literal["audio", "text", "both", "none"] = "audio",
         tts_enabled: bool = True,
         asr_muted: bool = False,
         llm_headers: dict[str, str] | None = None,
@@ -710,7 +710,7 @@ class Glados:
         self.subagent_manager.register(emotion_agent)
         self._emotion_agent = emotion_agent  # Keep reference for event pushing
         # Wire emotion agent to autonomy loop for vision events
-        if self.autonomy_config.enabled and hasattr(self, "autonomy_loop"):
+        if self.autonomy_config.enabled and self.autonomy_loop:
             self.autonomy_loop.set_emotion_agent(emotion_agent)
 
         # Compaction agent - monitors conversation size and compacts when needed
@@ -862,7 +862,10 @@ class Glados:
                 logger.error(f"Failed to start audio input: {e}")
                 logger.warning("Voice input disabled - text input still available")
         else:
-            logger.info("Text input mode active. Audio input is disabled.")
+            if self.input_mode == "none":
+                logger.info("No audio input mode active (TUI handles text input).")
+            else:
+                logger.info("Text input mode active. Audio input is disabled.")
 
         logger.success("Engine running")
         logger.success("Listening...")

--- a/src/glados/tui.py
+++ b/src/glados/tui.py
@@ -1403,8 +1403,14 @@ class GladosUI(App[None]):
         glados_config = GladosConfig.from_yaml(str(config_path))
         updates: dict[str, object] = {}
         if self._input_mode_override:
-            if self._input_mode_override in {"text", "both"}:
-                # Avoid stdin contention between Textual and TextListener.
+            if self._input_mode_override == "text":
+                # In TUI text mode, use "none" so neither audio stream nor TextListener
+                # is started. The TUI Input widget handles all text input, avoiding
+                # both high CPU from audio and stdin contention with TextListener.
+                updates["input_mode"] = "none"
+            elif self._input_mode_override == "both":
+                # In TUI+both mode, keep audio ASR active; the TUI Input widget handles
+                # text input, so TextListener is not needed (avoids stdin contention).
                 updates["input_mode"] = "audio"
             else:
                 updates["input_mode"] = self._input_mode_override

--- a/src/glados/tui.py
+++ b/src/glados/tui.py
@@ -1402,18 +1402,22 @@ class GladosUI(App[None]):
 
         glados_config = GladosConfig.from_yaml(str(config_path))
         updates: dict[str, object] = {}
-        if self._input_mode_override:
-            if self._input_mode_override == "text":
-                # In TUI text mode, use "none" so neither audio stream nor TextListener
-                # is started. The TUI Input widget handles all text input, avoiding
-                # both high CPU from audio and stdin contention with TextListener.
-                updates["input_mode"] = "none"
-            elif self._input_mode_override == "both":
-                # In TUI+both mode, keep audio ASR active; the TUI Input widget handles
-                # text input, so TextListener is not needed (avoids stdin contention).
-                updates["input_mode"] = "audio"
-            else:
-                updates["input_mode"] = self._input_mode_override
+        # Use the CLI override when supplied, otherwise fall back to whatever
+        # input_mode is in the YAML config. Both paths must remap "text"→"none"
+        # and "both"→"audio" for TUI to avoid stdin contention with TextListener
+        # and unnecessary audio stream startup.
+        effective_input_mode = self._input_mode_override or glados_config.input_mode
+        if effective_input_mode == "text":
+            # In TUI text mode, use "none" so neither audio stream nor TextListener
+            # is started. The TUI Input widget handles all text input, avoiding
+            # both high CPU from audio and stdin contention with TextListener.
+            updates["input_mode"] = "none"
+        elif effective_input_mode == "both":
+            # In TUI+both mode, keep audio ASR active; the TUI Input widget handles
+            # text input, so TextListener is not needed (avoids stdin contention).
+            updates["input_mode"] = "audio"
+        elif self._input_mode_override:
+            updates["input_mode"] = self._input_mode_override
         if self._tts_enabled_override is not None:
             updates["tts_enabled"] = self._tts_enabled_override
         if self._asr_muted_override is not None:


### PR DESCRIPTION
Fixes #188

## Problem
When `input_mode: "text"` is set in the config and GLaDOS is launched via the TUI (`glados tui`), the TUI was silently converting the mode to `"audio"` to avoid stdin contention between Textual and the `TextListener`. However, this kept the audio input stream running, causing:
- High CPU usage (related to #187, where the audio stream itself is the culprit)
- The resulting CPU load made the Textual UI sluggish, requiring each key to be pressed multiple times to register

## Solution
Introduced a new `"none"` input mode in the engine that starts neither `SpeechListener` (audio) nor `TextListener` (stdin). In TUI text mode, the Textual `Input` widget already handles all user text submission via `submit_text_input()`, so no additional listener is needed.

The mapping in the TUI is now:
- `input_mode: "text"` → engine uses `"none"` (no audio stream, no stdin listener → low CPU, responsive keyboard)
- `input_mode: "both"` → engine uses `"audio"` (ASR active, TUI Input handles text → was already correct)

## Testing
- Set `input_mode: "text"` in `glados_config.yaml`
- Launch with `glados tui`
- Keyboard input should now register on every keypress without lag
- CPU usage should be significantly reduced compared to before


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "none" input mode to disable both audio and text input.

* **Improvements**
  * TUI input handling refined: selecting text now disables audio while the TUI handles typing; selecting both keeps audio active alongside TUI input.
  * Run-time messages clarified to distinguish fully disabled audio from text-only operation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->