### PR TITLE
feat: specify multiple configuration files

### DIFF
--- a/src/glados/cli.py
+++ b/src/glados/cli.py
@@ -172,13 +172,13 @@ def models_valid() -> bool:
     return True
 
 
-def say(text: str, config_path: str | Path = "glados_config.yaml") -> None:
+def say(text: str, config_path: str | Path | list[str] | list[Path] = "glados_config.yaml") -> None:
     """
     Converts text to speech using the GLaDOS text-to-speech system and plays the generated audio.
 
     Parameters:
         text (str): The text to be spoken by the GLaDOS voice assistant.
-        config_path (str | Path, optional): Path to the configuration YAML file.
+        config_path (str | Path | list, optional): Path to the configuration YAML file(s).
             Defaults to "glados_config.yaml".
 
     Notes:
@@ -202,7 +202,7 @@ def say(text: str, config_path: str | Path = "glados_config.yaml") -> None:
 
 
 def start(
-    config_path: str | Path = "glados_config.yaml",
+    config_path: str | Path | list[str] | list[Path] = "glados_config.yaml",
     input_mode: str | None = None,
     tts_enabled: bool | None = None,
     asr_muted: bool | None = None,
@@ -214,7 +214,7 @@ def start(
     and begins the continuous listening process for voice interactions.
 
     Parameters:
-        config_path (str | Path, optional): Path to the configuration YAML file.
+        config_path (str | Path | list, optional): Path to the configuration YAML file(s).
             Defaults to "glados_config.yaml" in the current directory.
 
     Raises:
@@ -225,7 +225,7 @@ def start(
         start()  # Uses default configuration file
         start("/path/to/custom/config.yaml")  # Uses a custom configuration file
     """
-    glados_config = GladosConfig.from_yaml(str(config_path))
+    glados_config = GladosConfig.from_yaml(config_path)
     updates: dict[str, object] = {}
     if input_mode:
         updates["input_mode"] = input_mode
@@ -242,7 +242,7 @@ def start(
 
 
 def tui(
-    config_path: str | Path = "glados_config.yaml",
+    config_paths: str | Path | list[str] | list[Path] = "glados_config.yaml",
     input_mode: str | None = None,
     tts_enabled: bool | None = None,
     asr_muted: bool | None = None,
@@ -261,7 +261,7 @@ def tui(
 
     try:
         app = tui.GladosUI(
-            config_path=config_path,
+            config_paths=config_paths,
             input_mode=input_mode,
             tts_enabled=tts_enabled,
             asr_muted=asr_muted,
@@ -280,11 +280,28 @@ def parser_add_config(parser: argparse.ArgumentParser) -> None:
     Args:
         parser: parse to add the config argument to.
     """
+    class ReplaceDefaultArgsAction(argparse.Action):
+        """
+        A argparse action similar to 'append', but if any argument is specified, the default value is ignored
+        instead of the default argparse behaviour of appending to the default value.
+        """
+        def __call__(self, p: argparse.ArgumentParser, namespace: argparse.Namespace, values, option_string=None) -> None:
+            current_list = getattr(namespace, self.dest)
+            if current_list is self.default:
+                # same by identity - ignore default values, new value is the first element of the list
+                current_list = [values]
+            else:
+                # current_list already is custom - append to it
+                current_list = list(current_list)
+                current_list.append(values)
+            setattr(namespace, self.dest, current_list)
+
     parser.add_argument(
         "--config",
-        type=str,
-        default=DEFAULT_CONFIG,
-        help=f"Path to configuration file (default: {DEFAULT_CONFIG})",
+        type=Path,
+        default=[DEFAULT_CONFIG],
+        action=ReplaceDefaultArgsAction,
+        help=f"Path to configuration file (default: {DEFAULT_CONFIG}). You may specify this option more than once; the configuration settings in the later files override those in earlier ones.",
     )
 
 

--- a/src/glados/cli.py
+++ b/src/glados/cli.py
@@ -272,6 +272,67 @@ def tui(
         sys.exit()
 
 
+def parser_add_config(parser: argparse.ArgumentParser) -> None:
+    """
+    Add the '--config' argument to the given parser.
+    Used to reduce repetitions.
+
+    Args:
+        parser: parse to add the config argument to.
+    """
+    parser.add_argument(
+        "--config",
+        type=str,
+        default=DEFAULT_CONFIG,
+        help=f"Path to configuration file (default: {DEFAULT_CONFIG})",
+    )
+
+
+def parser_add_common_tui_cli_args(parser: argparse.ArgumentParser) -> None:
+    """
+    Add the arguments that are common for both the 'tui' command and the 'start' command to the given parser.
+    Includes the '--config' argument.
+
+    Args:
+        parser: parser to add the arguments to.
+    """
+    parser_add_config(parser)
+    parser.add_argument(
+        "--input-mode",
+        choices=["audio", "text", "both"],
+        default=None,
+        help="Override input mode (audio, text, or both)",
+    )
+    asr_group = parser.add_mutually_exclusive_group()
+    asr_group.add_argument(
+        "--asr-muted",
+        dest="asr_muted",
+        action="store_true",
+        help="Start with ASR muted",
+    )
+    asr_group.add_argument(
+        "--asr-unmuted",
+        dest="asr_muted",
+        action="store_false",
+        help="Start with ASR unmuted",
+    )
+    asr_group.set_defaults(asr_muted=None)
+    tts_group = parser.add_mutually_exclusive_group()
+    tts_group.add_argument(
+        "--tts-enabled",
+        dest="tts_enabled",
+        action="store_true",
+        help="Enable TTS output",
+    )
+    tts_group.add_argument(
+        "--tts-disabled",
+        dest="tts_enabled",
+        action="store_false",
+        help="Disable TTS output",
+    )
+    tts_group.set_defaults(tts_enabled=None)
+
+
 def main() -> int:
     """
     Command-line interface (CLI) entry point for the GLaDOS voice assistant.
@@ -299,89 +360,11 @@ def main() -> int:
 
     # Start command
     start_parser = subparsers.add_parser("start", help="Start GLaDOS voice assistant")
-    start_parser.add_argument(
-        "--config",
-        type=str,
-        default=DEFAULT_CONFIG,
-        help=f"Path to configuration file (default: {DEFAULT_CONFIG})",
-    )
-    start_parser.add_argument(
-        "--input-mode",
-        choices=["audio", "text", "both"],
-        default=None,
-        help="Override input mode (audio, text, or both)",
-    )
-    start_asr_group = start_parser.add_mutually_exclusive_group()
-    start_asr_group.add_argument(
-        "--asr-muted",
-        dest="asr_muted",
-        action="store_true",
-        help="Start with ASR muted",
-    )
-    start_asr_group.add_argument(
-        "--asr-unmuted",
-        dest="asr_muted",
-        action="store_false",
-        help="Start with ASR unmuted",
-    )
-    start_asr_group.set_defaults(asr_muted=None)
-    start_tts_group = start_parser.add_mutually_exclusive_group()
-    start_tts_group.add_argument(
-        "--tts-enabled",
-        dest="tts_enabled",
-        action="store_true",
-        help="Enable TTS output",
-    )
-    start_tts_group.add_argument(
-        "--tts-disabled",
-        dest="tts_enabled",
-        action="store_false",
-        help="Disable TTS output",
-    )
-    start_tts_group.set_defaults(tts_enabled=None)
+    parser_add_common_tui_cli_args(start_parser)
 
     # TUI command
     tui_parser = subparsers.add_parser("tui", help="Start GLaDOS voice assistant with TUI")
-    tui_parser.add_argument(
-        "--config",
-        type=str,
-        default=DEFAULT_CONFIG,
-        help=f"Path to configuration file (default: {DEFAULT_CONFIG})",
-    )
-    tui_parser.add_argument(
-        "--input-mode",
-        choices=["audio", "text", "both"],
-        default=None,
-        help="Override input mode (audio, text, or both)",
-    )
-    tui_asr_group = tui_parser.add_mutually_exclusive_group()
-    tui_asr_group.add_argument(
-        "--asr-muted",
-        dest="asr_muted",
-        action="store_true",
-        help="Start with ASR muted",
-    )
-    tui_asr_group.add_argument(
-        "--asr-unmuted",
-        dest="asr_muted",
-        action="store_false",
-        help="Start with ASR unmuted",
-    )
-    tui_asr_group.set_defaults(asr_muted=None)
-    tui_tts_group = tui_parser.add_mutually_exclusive_group()
-    tui_tts_group.add_argument(
-        "--tts-enabled",
-        dest="tts_enabled",
-        action="store_true",
-        help="Enable TTS output",
-    )
-    tui_tts_group.add_argument(
-        "--tts-disabled",
-        dest="tts_enabled",
-        action="store_false",
-        help="Disable TTS output",
-    )
-    tui_tts_group.set_defaults(tts_enabled=None)
+    parser_add_common_tui_cli_args(tui_parser)
     tui_parser.add_argument(
         "--theme",
         type=str,
@@ -392,12 +375,7 @@ def main() -> int:
     # Say command
     say_parser = subparsers.add_parser("say", help="Make GLaDOS speak text")
     say_parser.add_argument("text", type=str, help="Text for GLaDOS to speak")
-    say_parser.add_argument(
-        "--config",
-        type=str,
-        default=DEFAULT_CONFIG,
-        help=f"Path to configuration file (default: {DEFAULT_CONFIG})",
-    )
+    parser_add_config(say_parser)
 
     args = parser.parse_args()
 

--- a/src/glados/core/engine.py
+++ b/src/glados/core/engine.py
@@ -124,12 +124,13 @@ class GladosConfig(BaseModel):
     mcp_servers: list[MCPServerConfig] | None = None
 
     @classmethod
-    def from_yaml(cls, path: str | Path, key_to_config: tuple[str, ...] = ("Glados",)) -> "GladosConfig":
+    def from_yaml(cls, paths: str | Path | list[str] | list[Path], key_to_config: tuple[str, ...] = ("Glados",)) -> "GladosConfig":
         """
-        Load a GladosConfig instance from a YAML configuration file.
+        Load a GladosConfig instance from one or more configuration files.
+        Explicitly specified options in later configuration files override options specified in earlier files.
 
         Parameters:
-            path: Path to the YAML configuration file
+            paths: Path to one or multiple YAML configuration files
             key_to_config: Tuple of keys to navigate nested configuration
 
         Returns:
@@ -137,24 +138,35 @@ class GladosConfig(BaseModel):
 
         Raises:
             ValueError: If the YAML content is invalid
-            OSError: If the file cannot be read
+            OSError: If a file cannot be read
             pydantic.ValidationError: If the configuration is invalid
         """
-        path = Path(path)
 
-        # Try different encodings
-        for encoding in ["utf-8", "utf-8-sig"]:
-            try:
-                data = yaml.safe_load(path.read_text(encoding=encoding))
-                break
-            except UnicodeDecodeError:
-                if encoding == "utf-8-sig":
-                    raise ValueError(f"Could not decode YAML file {path} with any supported encoding")
+        # if config is a single path, create a single-element list
+        if isinstance(paths, str) or isinstance(paths, Path):
+            paths = [paths]
 
-        # Navigate through nested keys
-        config = data
-        for key in key_to_config:
-            config = config[key]
+        config = dict()
+
+        for path in paths:
+            path = Path(path)
+
+            # Try different encodings
+            for encoding in ["utf-8", "utf-8-sig"]:
+                try:
+                    data = yaml.safe_load(path.read_text(encoding=encoding))
+                    break
+                except UnicodeDecodeError:
+                    if encoding == "utf-8-sig":
+                        raise ValueError(f"Could not decode YAML file {path} with any supported encoding")
+
+            # Navigate through nested keys
+            for key in key_to_config:
+                data = data[key]
+
+            # Update config dict - config from later paths overrides earlier config
+            for key, value in data.items():
+                config[key] = value
 
         return cls.model_validate(config)
 
@@ -833,15 +845,16 @@ class Glados:
         )
 
     @classmethod
-    def from_yaml(cls, path: str) -> "Glados":
+    def from_yaml(cls, path: str | Path | list[str] | list[Path]) -> "Glados":
         """
-        Create a Glados instance from a configuration file.
+        Create a Glados instance from one or more configuration files.
+        Explicitly specified options in later configuration files override options specified in earlier files.
 
         Parameters:
-            path (str): Path to the YAML configuration file containing Glados settings.
+            path: One or multiple paths to the YAML configuration file(s) containing Glados settings.
 
         Returns:
-            Glados: A new Glados instance configured with settings from the specified YAML file.
+            Glados: A new Glados instance configured with settings from the specified YAML file(s).
 
         Example:
             glados = Glados.from_yaml('config/default.yaml')

--- a/src/glados/core/engine.py
+++ b/src/glados/core/engine.py
@@ -160,6 +160,8 @@ class GladosConfig(BaseModel):
                     if encoding == "utf-8-sig":
                         raise ValueError(f"Could not decode YAML file {path} with any supported encoding")
 
+            data = data or dict()
+
             # Navigate through nested keys
             for key in key_to_config:
                 data = data[key]

--- a/src/glados/core/engine.py
+++ b/src/glados/core/engine.py
@@ -165,10 +165,26 @@ class GladosConfig(BaseModel):
                 data = data[key]
 
             # Update config dict - config from later paths overrides earlier config
-            for key, value in data.items():
-                config[key] = value
+            config = GladosConfig._dict_deep_merge(config, data)
 
         return cls.model_validate(config)
+
+    @staticmethod
+    def _dict_deep_merge(a: dict, b: dict) -> dict:
+        """
+        Recursively merge two dictionaries into one.
+        Values from the second dictionary override values from the first.
+        Note: mutates the first dictionary.
+
+        Returns:
+            The merged dictionary.
+        """
+        for key in b:
+            if key in a and isinstance(a[key], dict) and isinstance(b[key], dict):
+                GladosConfig._dict_deep_merge(a[key], b[key])
+            else:
+                a[key] = b[key]
+        return a
 
     def to_chat_messages(self) -> list[dict[str, str]]:
         """Convert personality preprompt to chat message format."""

--- a/src/glados/tui.py
+++ b/src/glados/tui.py
@@ -489,7 +489,7 @@ class SplashScreen(Screen[None]):
         model = "unknown"
         endpoint = "unknown"
         try:
-            config = GladosConfig.from_yaml(str(app._config_path))
+            config = GladosConfig.from_yaml(app._config_paths)
             model = config.llm_model
             endpoint = self._format_endpoint(str(config.completion_url))
         except Exception as exc:
@@ -935,7 +935,7 @@ class GladosUI(App[None]):
     _autonomy_panel: AutonomyPanel | None = None
     _mcp_panel: MCPPanel | None = None
     _queue_metrics: dict[str, dict[str, float | int | None]]
-    _config_path: Path
+    _config_paths: list[Path]
     _input_mode_override: str | None
     _tts_enabled_override: bool | None
     _asr_muted_override: bool | None
@@ -944,7 +944,7 @@ class GladosUI(App[None]):
 
     def __init__(
         self,
-        config_path: str | Path | None = None,
+        config_paths: str | Path | list[str] | list[Path] | None = None,
         input_mode: str | None = None,
         tts_enabled: bool | None = None,
         asr_muted: bool | None = None,
@@ -952,7 +952,15 @@ class GladosUI(App[None]):
     ) -> None:
         super().__init__()
         default_config = resource_path("configs/glados_config.yaml")
-        self._config_path = Path(config_path) if config_path else Path(default_config)
+        if isinstance(config_paths, list):
+            # is already list - convert each element to Path
+            self._config_paths = list(Path(p) for p in config_paths)
+        elif config_paths is not None:
+            # single element - convert to list[Path]
+            self._config_paths = [Path(config_paths)]
+        else:
+            # None
+            self._config_paths = [Path(default_config)]
         self._input_mode_override = input_mode
         self._tts_enabled_override = tts_enabled
         self._asr_muted_override = asr_muted
@@ -1276,7 +1284,7 @@ class GladosUI(App[None]):
         if self._theme_override:
             return self._theme_override
         try:
-            config = GladosConfig.from_yaml(str(self._config_path))
+            config = GladosConfig.from_yaml(self._config_paths)
             if config.tui_theme:
                 return config.tui_theme
         except Exception as exc:
@@ -1396,11 +1404,11 @@ class GladosUI(App[None]):
             Glados: An instance of the GLaDOS engine.
         """
 
-        config_path = self._config_path
-        if not config_path.exists():
-            logger.error(f"GLaDOS config file not found: {config_path}")
+        config_paths = self._config_paths
+        if not all(p.exists() for p in config_paths):
+            logger.error(f"GLaDOS config file not found: {config_paths}")
 
-        glados_config = GladosConfig.from_yaml(str(config_path))
+        glados_config = GladosConfig.from_yaml(config_paths)
         updates: dict[str, object] = {}
         if self._input_mode_override:
             if self._input_mode_override in {"text", "both"}:

--- a/src/glados/tui.py
+++ b/src/glados/tui.py
@@ -1406,7 +1406,10 @@ class GladosUI(App[None]):
 
         config_paths = self._config_paths
         if not all(p.exists() for p in config_paths):
-            logger.error(f"GLaDOS config file not found: {config_paths}")
+            missing = list(p for p in config_paths if not p.exists())
+            msg = f"GLaDOS config file(s) not found: {missing}"
+            logger.error(msg)
+            raise FileNotFoundError(msg)
 
         glados_config = GladosConfig.from_yaml(config_paths)
         updates: dict[str, object] = {}


### PR DESCRIPTION
This PR introduces the ability to specify multiple configuration files in the CLI arguments, with (explicitly set) options in later configuration files overwriting options set in earlier configuration files.

Since I was already changing the code, I also cleaned up the CLI parsing to be less repetitive.

My use case for this feature: to have  a "public" configuration file that can be committed and a secret configuration file with e.g. the LLM API key.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for multiple configuration files: repeated --config entries; commands, TUI, and quick-say accept and merge multiple config paths (later files override earlier).
  * TUI now exposes a theme option and accepts multi-path config input.

* **Bug Fixes**
  * Robust config loading with encoding fallbacks and clearer error reporting listing missing config files.

* **Refactor**
  * CLI argument handling reorganized into shared helpers for consistent options across commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->