### PR TITLE
fix: limit ONNX Runtime threads in VAD to reduce idle CPU usage

### DIFF
--- a/src/glados/audio_io/vad.py
+++ b/src/glados/audio_io/vad.py
@@ -31,9 +31,17 @@ class VAD:
         if "CoreMLExecutionProvider" in providers:
             providers.remove("CoreMLExecutionProvider")
 
+        # Limit to 1 thread to prevent ONNX Runtime from spawning many threads
+        # for each small inference call (~31/sec). On high core-count machines this
+        # causes excessive CPU usage; Silero VAD is small enough that single-threaded
+        # inference has negligible latency impact. (Fixes #187)
+        sess_options = ort.SessionOptions()
+        sess_options.intra_op_num_threads = 1
+        sess_options.inter_op_num_threads = 1
+
         self.ort_sess = ort.InferenceSession(
             model_path,
-            sess_options=ort.SessionOptions(),
+            sess_options=sess_options,
             providers=providers,
         )
 


### PR DESCRIPTION
Fixes #187

## Problem

On high core-count machines (e.g. 24-core i7-13700KF), `glados tui` causes disproportionately high idle CPU usage. As reported, switching to `input_mode: text` drops CPU from high% to ~2%, confirming the audio input pipeline is the culprit.

The root cause: ONNX Runtime defaults to using all available CPU threads for each inference call. With Silero VAD running at ~31 calls/second (one per 32ms audio chunk), this causes excessive thread churn on high core-count machines even when idle.

## Solution

Set intra_op_num_threads=1 and inter_op_num_threads=1 on the ONNX SessionOptions. Silero VAD is a compact RNN whose single-threaded inference latency is well under 1ms, so there is no perceptible impact on responsiveness.

## Testing

Verified the VAD still correctly classifies speech vs. silence with the thread limits in place.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized Voice Activity Detection initialization for improved resource efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->