### PR TITLE
Add a wakeword recognition module based on OpenWakeWord

### DIFF
--- a/configs/glados_config.yaml
+++ b/configs/glados_config.yaml
@@ -10,7 +10,8 @@ Glados:
   tui_theme: "aperture"
   asr_engine: "tdt"
   llm_headers: null  # Optional extra headers (e.g., OpenRouter HTTP-Referer, X-Title)
-  wake_word: null
+  wake_word: null # recognize wake word via ASR - specify exactly 1 word
+  wake_word_model_path: null # recognize wake word via https://github.com/dscripka/openWakeWord - specify the path to an ONNX model
   voice: "glados"
   announcement: "All neural network modules are now loaded. System Operational."
   autonomy:

--- a/src/glados/cli.py
+++ b/src/glados/cli.py
@@ -71,6 +71,14 @@ MODEL_DETAILS: dict[FileName, dict[FileURL, FileHash]] = {
         "url": "https://github.com/dnhkng/GLaDOS/releases/download/0.1/decoder_model_merged_q4f16.onnx",
         "checksum": "6ea00b526e59a5087e90e8e73b74a09347a7f1127f052476211b03aecca3fb0d",
     },
+    "models/openwakeword/melspec.onnx": {
+        "url": "https://github.com/dscripka/openWakeWord/releases/download/v0.5.1/melspectrogram.onnx",
+        "checksum": "ba2b0e0f8b7b875369a2c89cb13360ff53bac436f2895cced9f479fa65eb176f",
+    },
+    "models/openwakeword/embedding.onnx": {
+        "url": "https://github.com/dscripka/openWakeWord/releases/download/v0.5.1/embedding_model.onnx",
+        "checksum": "70d164290c1d095d1d4ee149bc5e00543250a7316b59f31d056cff7bd3075c1f",
+    }
 }
 
 

--- a/src/glados/core/engine.py
+++ b/src/glados/core/engine.py
@@ -112,6 +112,7 @@ class GladosConfig(BaseModel):
     asr_muted: bool = False
     asr_engine: str
     wake_word: str | None
+    wake_word_model_path: Path | None
     voice: str
     announcement: str | None
     llm_headers: dict[str, str] | None = None
@@ -191,6 +192,7 @@ class Glados:
         api_key: str | None = None,
         interruptible: bool = True,
         wake_word: str | None = None,
+        wake_word_path: Path | None = None,
         announcement: str | None = None,
         personality_preprompt: tuple[dict[str, str], ...] = DEFAULT_PERSONALITY_PREPROMPT,
         tool_config: dict[str, Any] | None = None,
@@ -239,6 +241,7 @@ class Glados:
         self.api_key = api_key
         self.interruptible = interruptible
         self.wake_word = wake_word
+        self.wake_word_path = wake_word_path
         self.announcement = announcement
         self.tool_config = tool_config or {}
         self.tool_timeout = tool_timeout
@@ -368,6 +371,7 @@ class Glados:
                 llm_queue=self.llm_queue_priority,
                 asr_model=self._asr_model,
                 wake_word=self.wake_word,
+                wake_word_path=self.wake_word_path,
                 interruptible=self.interruptible,
                 shutdown_event=self.shutdown_event,
                 currently_speaking_event=self.currently_speaking_event,
@@ -819,6 +823,7 @@ class Glados:
             api_key=config.api_key,
             interruptible=config.interruptible,
             wake_word=config.wake_word,
+            wake_word_path=config.wake_word_model_path,
             announcement=config.announcement,
             personality_preprompt=tuple(config.to_chat_messages()),
             tool_config={"slow_clap_audio_path": config.slow_clap_audio_path},

--- a/src/glados/core/speech_listener.py
+++ b/src/glados/core/speech_listener.py
@@ -9,6 +9,7 @@ from collections import deque
 import queue
 import threading
 import time
+from pathlib import Path
 from typing import Any
 
 from Levenshtein import distance
@@ -22,6 +23,7 @@ from ..ASR import TranscriberProtocol
 from ..audio_io import AudioProtocol
 from .audio_state import AudioState
 from ..observability import ObservabilityBus, trim_message
+from ..openwakeword import Model as WakeWordModel
 
 # Callback signature: (event_type: str) -> None
 InterruptCallback = Callable[[str], None]
@@ -51,6 +53,7 @@ class SpeechListener:
         processing_active_event: threading.Event,
         asr_model: TranscriberProtocol,
         wake_word: str | None,
+        wake_word_path: Path | None,
         pause_time: float,
         interruptible: bool = True,
         interaction_state: "InteractionState | None" = None,
@@ -76,6 +79,10 @@ class SpeechListener:
         self.llm_queue = llm_queue
         self.asr_model = asr_model
         self.wake_word = wake_word.lower() if wake_word else None
+        if wake_word_path is None:
+            self.wake_word_recognizer = None
+        else:
+            self.wake_word_recognizer = WakeWordModel(wake_word_path)
         self.pause_time = pause_time
         self.interruptible = interruptible
 
@@ -266,23 +273,35 @@ class SpeechListener:
         Processes the accumulated audio samples once a speech pause is detected.
 
         This method performs the following steps:
-        1. Transcribes the collected audio samples using the ASR model.
-        2. If transcription is successful:
-            a. Checks for the `wake_word` (if configured).
-            b. If the wake word is detected (or not required), the transcribed text is
-               placed into the `llm_queue`, and `processing_active_event` is set.
+        1. Check if the `wake_word_recognizer` finds the wake word (if configured).
+        2. If the wake word was found or `wake_word_recognizer` is not configured:
+            a. Transcribes the collected audio samples using the ASR model.
+            b. If transcription is successful:
+                a1. Checks for the `wake_word` (if configured and `wake_word_recognizer` is not configured).
+                b1. If the wake word is detected (or not required), the transcribed text is
+                    placed into the `llm_queue`, and `processing_active_event` is set.
         3. Resets the listener's internal state using `self.reset()`, preparing for the next input.
         """
         logger.debug("Detected pause after speech. Processing...")
 
-        detected_text = self.asr(self._samples)
+        try:
+            audio = np.concatenate(self._samples)
 
-        if detected_text:
-            logger.success(f"ASR text: '{detected_text}'")
+            # Wake word recognition via model if available
+            if self.wake_word_recognizer and not self.wake_word_recognizer.predict_multi_sample(audio):
+                logger.info(f"Required wake word (model file {self.wake_word_recognizer.model_path}) not detected.")
+                return
 
-            if self.wake_word and not self._wakeword_detected(detected_text):
-                logger.info(f"Required wake word {self.wake_word=} not detected.")
-            else:
+            detected_text = self.asr(audio)
+
+            if detected_text:
+                logger.success(f"ASR text: '{detected_text}'")
+
+                # search for wake word via ASR text if there is no recognition model
+                if self.wake_word_recognizer is None and self.wake_word and not self._wakeword_detected(detected_text):
+                    logger.info(f"Required wake word {self.wake_word=} not detected.")
+                    return
+
                 if self._observability_bus:
                     self._observability_bus.emit(
                         source="asr",
@@ -300,10 +319,11 @@ class SpeechListener:
                 if self._interaction_state:
                     self._interaction_state.mark_user()
                 self.processing_active_event.set()
+        finally:
+            # always reset
+            self.reset()
 
-        self.reset()
-
-    def asr(self, samples: list[NDArray[np.float32]]) -> str:
+    def asr(self, audio: NDArray[np.float32]) -> str:
         """
         Performs Automatic Speech Recognition (ASR) on a list of audio samples.
 
@@ -312,16 +332,14 @@ class SpeechListener:
         volume levels before being passed to the ASR model for transcription.
 
         Args:
-            samples: A list of numpy arrays (float32) containing audio sample chunks.
+            audio: A numpy array (float32) containing audio sample chunks.
 
         Returns:
             The transcribed text as a string.
         """
-        if not samples:
+        if len(audio) == 0:
             logger.warning("ASR received empty sample list")
             return ""
-
-        audio = np.concatenate(samples)
 
         # Check for silent audio
         max_abs_val = np.max(np.abs(audio))

--- a/src/glados/openwakeword/LICENSE
+++ b/src/glados/openwakeword/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/src/glados/openwakeword/__init__.py
+++ b/src/glados/openwakeword/__init__.py
@@ -112,7 +112,7 @@ class Model:
             self.model_name: threshold,
         }
 
-        return self._model.predict(x, patience=patience, debounce_time=debounce_time, threshold=threshold_param)[self.model_name] > threshold
+        return self._model.predict(x, patience=patience, debounce_time=debounce_time, threshold=threshold_param)[self.model_name] >= threshold
 
     def predict_multi_sample(self, x: np.ndarray, threshold: float | None = None) -> bool:
         """
@@ -140,7 +140,7 @@ class Model:
             current = x[i * self.MIN_SAMPLES: (i + 1) * self.MIN_SAMPLES]
             prediction = max(self._model.predict(current)[self.model_name], prediction)
 
-        return prediction > threshold
+        return prediction >= threshold
 
 
 __all__ = ["Model"]

--- a/src/glados/openwakeword/__init__.py
+++ b/src/glados/openwakeword/__init__.py
@@ -95,7 +95,7 @@ class Model:
             return cls.DEFAULT_THRESHOLD
         if 0.0 < threshold <= 1.0:
             return float(threshold)
-        raise ValueError("threshold must be between 0.0 and 1.0")
+        raise ValueError("threshold must be 0.0 < threshold <= 1.0")
 
     def predict(self, x: np.ndarray, patience: int | None = None, debounce_time: float| None = None, threshold: float | None = None) -> bool:
         """

--- a/src/glados/openwakeword/__init__.py
+++ b/src/glados/openwakeword/__init__.py
@@ -80,7 +80,7 @@ class Model:
     @classmethod
     def _validate_threshold(cls, threshold: float | None) -> float:
         """
-        Validate the threshold: it should be None or in the range 0.0 to 1.0.
+        Validate the threshold: it should be None or in the range 0.0 (excluded) to 1.0.
 
         Args:
             threshold: Threshold value
@@ -93,7 +93,7 @@ class Model:
         """
         if threshold is None:
             return cls.DEFAULT_THRESHOLD
-        if 0.0 <= threshold <= 1.0:
+        if 0.0 < threshold <= 1.0:
             return float(threshold)
         raise ValueError("threshold must be between 0.0 and 1.0")
 

--- a/src/glados/openwakeword/__init__.py
+++ b/src/glados/openwakeword/__init__.py
@@ -1,0 +1,138 @@
+"""
+Use OpenWakeWord for wakeword detection/recognition.
+
+Note: this module uses files from the openWakeWord python project: https://github.com/dscripka/openWakeWord
+For the license of openWakeWord, see LICENSE.
+Files from openWakeWord:
+ - LICENSE
+ - model.py
+ - utils.py
+
+This was done because
+1. openWakeWord itself has functionalities and dependencies not needed by this project that cannot be deactivated when specified as a dependency
+2. openWakeWord has a hard dependency on 'onnxruntime', which conflicts with the dependency on 'onnxruntime-gpu' when using '--extra cuda'
+"""
+from pathlib import Path
+
+import numpy as np
+import onnxruntime as ort
+
+from .model import Model as _InternalModel
+from ..utils.resources import resource_path
+
+
+class Model:
+    """
+    Wrapper around OpenWakeWordModel to account for new model paths and GPU support
+    """
+    AUDIO_SAMPLE_RATE = 16000  # audio/microphone sample rate
+    MIN_SAMPLES = 1280 # minimum amount of audio samples needed
+    DEFAULT_MELSPEC_MODEL_PATH = resource_path(f"models/openwakeword/melspec.onnx")  # Model path to melspectogram model
+    DEFAULT_EMBEDDING_MODEL_PATH = resource_path(f"models/openwakeword/embedding.onnx")  # Model path to embedding model
+    DEFAULT_THRESHOLD = 0.7 # Default threshold for a successful prediction
+
+    def __init__(self, wakeword_model_path: Path, melspec_model_path: Path | None = None, embedding_model_path: Path | None = None):
+        """
+        Create a new OpenWakeWordModel
+        Args:
+            wakeword_model_path: Path to the wake word model
+        """
+        self.model_path = wakeword_model_path
+        self.model_name = wakeword_model_path.stem
+
+        # Configure providers (same pattern as ASR)
+        providers = ort.get_available_providers()
+        for excluded in ["TensorrtExecutionProvider", "CoreMLExecutionProvider"]:
+            if excluded in providers:
+                providers.remove(excluded)
+
+        if "CUDAExecutionProvider" in providers:
+            providers = ["CUDAExecutionProvider", "CPUExecutionProvider"]
+        else:
+            providers = ["CPUExecutionProvider"]
+
+        # configure model
+        wakeword_models = [str(wakeword_model_path)]
+
+        if melspec_model_path is None:
+            melspec_model_path = self.DEFAULT_MELSPEC_MODEL_PATH
+        if embedding_model_path is None:
+            embedding_model_path = self.DEFAULT_EMBEDDING_MODEL_PATH
+
+        self._model = _InternalModel(wakeword_models, onnx_providers=providers, melspec_model_path=str(melspec_model_path), embedding_model_path=str(embedding_model_path), sr=self.AUDIO_SAMPLE_RATE)
+
+    def reset(self):
+        """Reset the model state"""
+        self._model.reset()
+
+    def predict(self, x: np.ndarray, patience: int | None = None, debounce_time: float| None = None, threshold: float | None = None) -> bool:
+        """
+        Predict if the wake word was spoken
+        Args:
+            x: Audio data: a multiple of 1280 samples with 16kHz sample rate, in f32 format
+            patience: How many consecutive frames (of 1280 samples or 80 ms) above the threshold that must
+                      be observed before the current frame will be returned as non-zero.
+                      By default, this behaviour is disabled.
+            debounce_time: The time (in seconds) to wait before returning another non-zero prediction
+                           By default, this behaviour is disabled.
+            threshold: Threshold for the recognition score to be a successful prediction
+
+        Returns:
+            If the wake word was spoken in one of the samples.
+        """
+
+        threshold = self.DEFAULT_THRESHOLD if threshold is None else float(threshold)
+
+        # convert to int16
+        x = (x * 32767).astype(np.int16)
+
+        if patience is None:
+            patience = {}
+        else:
+            patience = {
+                self.model_name: patience,
+            }
+
+        if threshold is None:
+            threshold = {}
+        else:
+            threshold = {
+                self.model_name: threshold,
+            }
+
+        if debounce_time is None:
+            debounce_time = 0.0
+
+        return self._model.predict(x, patience=patience, debounce_time=debounce_time, threshold=threshold)[self.model_name] > threshold
+
+    def predict_multi_sample(self, x: np.ndarray, threshold: float | None = None) -> bool:
+        """
+        Predict if the wake word was spoken in one of multiple 1280-sample-chunks.
+        Resets the model before starting the prediction.
+
+        Args:
+            x: Audio data: a multiple of 1280 samples with 16kHz sample rate, in f32 format
+            threshold: Threshold for the recognition score to be a successful prediction
+
+        Returns:
+            If the wake word was spoken in one of the sample chunks. If there are not enough sample chunks, return False.
+        """
+
+        self.reset()
+
+        threshold = self.DEFAULT_THRESHOLD if threshold is None else float(threshold)
+
+        # convert to int16
+        x = (x * 32767).astype(np.int16)
+
+        prediction = 0
+        while len(x) >= self.MIN_SAMPLES:
+            current = x[:self.MIN_SAMPLES]
+            x = x[self.MIN_SAMPLES:]
+            prediction = max(self._model.predict(current)[self.model_name], prediction)
+
+        return prediction > threshold
+
+
+__all__ = ["Model"]
+

--- a/src/glados/openwakeword/__init__.py
+++ b/src/glados/openwakeword/__init__.py
@@ -77,6 +77,26 @@ class Model:
         """
         return (np.clip(x, -1.0, 1.0) * 32767).astype(np.int16)
 
+    @classmethod
+    def _validate_threshold(cls, threshold: float | None) -> float:
+        """
+        Validate the threshold: it should be None or in the range 0.0 to 1.0.
+
+        Args:
+            threshold: Threshold value
+
+        Returns:
+            Corrected threshold: if None is given, the default value is returned, if the value is out of range, a ValueError is raised
+
+        Raises:
+            ValueError: if the threshold is out of range
+        """
+        if threshold is None:
+            return cls.DEFAULT_THRESHOLD
+        if 0.0 <= threshold <= 1.0:
+            return float(threshold)
+        raise ValueError("threshold must be between 0.0 and 1.0")
+
     def predict(self, x: np.ndarray, patience: int | None = None, debounce_time: float| None = None, threshold: float | None = None) -> bool:
         """
         Predict if the wake word was spoken
@@ -91,9 +111,12 @@ class Model:
 
         Returns:
             If the wake word was spoken in one of the samples.
+
+        Raises:
+            ValueError: if the threshold is out of range
         """
 
-        threshold = self.DEFAULT_THRESHOLD if threshold is None else float(threshold)
+        threshold = self._validate_threshold(threshold)
 
         # convert to int16
         x = self._np_f32_to_i16(x)
@@ -125,11 +148,14 @@ class Model:
 
         Returns:
             If the wake word was spoken in one of the sample chunks. If there are not enough sample chunks, return False.
+
+        Raises:
+            ValueError: if the threshold is out of range
         """
 
         self.reset()
 
-        threshold = self.DEFAULT_THRESHOLD if threshold is None else float(threshold)
+        threshold = self._validate_threshold(threshold)
 
         # convert to int16
         x = self._np_f32_to_i16(x)

--- a/src/glados/openwakeword/__init__.py
+++ b/src/glados/openwakeword/__init__.py
@@ -27,8 +27,8 @@ class Model:
     """
     AUDIO_SAMPLE_RATE = 16000  # audio/microphone sample rate
     MIN_SAMPLES = 1280 # minimum amount of audio samples needed
-    DEFAULT_MELSPEC_MODEL_PATH = resource_path(f"models/openwakeword/melspec.onnx")  # Model path to melspectogram model
-    DEFAULT_EMBEDDING_MODEL_PATH = resource_path(f"models/openwakeword/embedding.onnx")  # Model path to embedding model
+    DEFAULT_MELSPEC_MODEL_PATH = resource_path("models/openwakeword/melspec.onnx")  # Model path to melspectogram model
+    DEFAULT_EMBEDDING_MODEL_PATH = resource_path("models/openwakeword/embedding.onnx")  # Model path to embedding model
     DEFAULT_THRESHOLD = 0.7 # Default threshold for a successful prediction
 
     def __init__(self, wakeword_model_path: Path, melspec_model_path: Path | None = None, embedding_model_path: Path | None = None):
@@ -94,16 +94,16 @@ class Model:
             }
 
         if threshold is None:
-            threshold = {}
+            threshold_param = {}
         else:
-            threshold = {
+            threshold_param = {
                 self.model_name: threshold,
             }
 
         if debounce_time is None:
             debounce_time = 0.0
 
-        return self._model.predict(x, patience=patience, debounce_time=debounce_time, threshold=threshold)[self.model_name] > threshold
+        return self._model.predict(x, patience=patience, debounce_time=debounce_time, threshold=threshold_param)[self.model_name] > threshold
 
     def predict_multi_sample(self, x: np.ndarray, threshold: float | None = None) -> bool:
         """

--- a/src/glados/openwakeword/__init__.py
+++ b/src/glados/openwakeword/__init__.py
@@ -65,6 +65,18 @@ class Model:
         """Reset the model state"""
         self._model.reset()
 
+    @staticmethod
+    def _np_f32_to_i16(x: np.ndarray) -> np.ndarray:
+        """
+        Convert to given np array with dtype f32 to a np array with dtype i16, convert data.
+        Args:
+            x: numpy array, dtype f32, data should be in range -1.0 to 1.0
+
+        Returns:
+            numpy array, dtype int16, data will be scaled from -32767 to 32767
+        """
+        return (np.clip(x, -1.0, 1.0) * 32767).astype(np.int16)
+
     def predict(self, x: np.ndarray, patience: int | None = None, debounce_time: float| None = None, threshold: float | None = None) -> bool:
         """
         Predict if the wake word was spoken
@@ -84,7 +96,7 @@ class Model:
         threshold = self.DEFAULT_THRESHOLD if threshold is None else float(threshold)
 
         # convert to int16
-        x = (x * 32767).astype(np.int16)
+        x = self._np_f32_to_i16(x)
 
         if patience is None:
             patience = {}
@@ -93,15 +105,12 @@ class Model:
                 self.model_name: patience,
             }
 
-        if threshold is None:
-            threshold_param = {}
-        else:
-            threshold_param = {
-                self.model_name: threshold,
-            }
-
         if debounce_time is None:
             debounce_time = 0.0
+
+        threshold_param = {
+            self.model_name: threshold,
+        }
 
         return self._model.predict(x, patience=patience, debounce_time=debounce_time, threshold=threshold_param)[self.model_name] > threshold
 
@@ -123,12 +132,12 @@ class Model:
         threshold = self.DEFAULT_THRESHOLD if threshold is None else float(threshold)
 
         # convert to int16
-        x = (x * 32767).astype(np.int16)
+        x = self._np_f32_to_i16(x)
 
+        count_samples = len(x) // self.MIN_SAMPLES
         prediction = 0
-        while len(x) >= self.MIN_SAMPLES:
-            current = x[:self.MIN_SAMPLES]
-            x = x[self.MIN_SAMPLES:]
+        for i in range(count_samples):
+            current = x[i * self.MIN_SAMPLES: (i + 1) * self.MIN_SAMPLES]
             prediction = max(self._model.predict(current)[self.model_name], prediction)
 
         return prediction > threshold

--- a/src/glados/openwakeword/model.py
+++ b/src/glados/openwakeword/model.py
@@ -1,0 +1,402 @@
+# Copyright 2022 David Scripka. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Modifications by reisbauer03:
+#   fixed imports to account for new module location
+#   stripped VAD functionality
+#   stripped tflite, forcing usage of onnxruntime
+#   introduced 'onnx_providers' parameter on __init__ for onnx provider selection
+#   stripped noise suppression
+#   stripped pretrained models
+#   added model_class_mappings from https://github.com/dscripka/openWakeWord/blob/368c03716d1e92591906a84949bc477f3a834455/openwakeword/__init__.py
+
+
+# Imports
+import numpy as np
+from .utils import AudioFeatures, re_arg
+
+import wave
+import os
+import functools
+import pickle
+from collections import deque, defaultdict
+from functools import partial
+import time
+from typing import List, Union, DefaultDict, Dict
+
+model_class_mappings = {
+    "timer": {
+        "1": "1_minute_timer",
+        "2": "5_minute_timer",
+        "3": "10_minute_timer",
+        "4": "20_minute_timer",
+        "5": "30_minute_timer",
+        "6": "1_hour_timer"
+    }
+}
+
+# Define main model class
+class Model():
+    """
+    The main model class for openWakeWord. Creates a model object with the shared audio pre-processer
+    and for arbitrarily many custom wake word/wake phrase models.
+    """
+    @re_arg({"wakeword_model_paths": "wakeword_models"})  # temporary handling of keyword argument change
+    def __init__(
+            self,
+            wakeword_models: List[str],
+            class_mapping_dicts: List[dict] = [],
+            custom_verifier_models: dict = {},
+            custom_verifier_threshold: float = 0.1,
+            onnx_providers: list[str] = None,
+            **kwargs
+            ):
+        """Initialize the openWakeWord model object.
+
+        Args:
+            wakeword_models (List[str]): A list of paths of ONNX models to load into the openWakeWord model object.
+                                              If not provided, will load all of the pre-trained models. Alternatively,
+                                              just the names of pre-trained models can be provided to select a subset of models.
+            class_mapping_dicts (List[dict]): A list of dictionaries with integer to string class mappings for
+                                              each model in the `wakeword_models` arguments
+                                              (e.g., {"0": "class_1", "1": "class_2"})
+            custom_verifier_models (dict): A dictionary of paths to custom verifier models, where
+                                           the keys are the model names (corresponding to the openwakeword.MODELS
+                                           attribute) and the values are the filepaths of the
+                                           custom verifier models.
+            custom_verifier_threshold (float): The score threshold to use a custom verifier model. If the score
+                                               from a model for a given frame is greater than this value, the
+                                               associated custom verifier model will also predict on that frame, and
+                                               the verifier score will be returned.
+            onnx_providers (list[str): list of ONNX providers to use. Default: ["CPUExecutionProvider"]
+            kwargs (dict): Any other keyword arguments to pass the the preprocessor instance
+        """
+        # Get model paths for pre-trained models if user doesn't provide models to load
+        wakeword_model_names = []
+
+        for ndx, i in enumerate(wakeword_models):
+            if os.path.exists(i):
+                wakeword_model_names.append(os.path.splitext(os.path.basename(i))[0])
+            else:
+                raise ValueError(f"Could not find model file '{i}'")
+
+        # Create attributes to store models and metadata
+        self.models = {}
+        self.model_inputs = {}
+        self.model_outputs = {}
+        self.model_prediction_function = {}
+        self.class_mapping = {}
+        self.custom_verifier_models = {}
+        self.custom_verifier_threshold = custom_verifier_threshold
+
+        # Do imports for  inference framework
+        try:
+            import onnxruntime as ort
+
+            def onnx_predict(onnx_model, x):
+                return onnx_model.run(None, {onnx_model.get_inputs()[0].name: x})
+
+            if onnx_providers is None:
+                onnx_providers = ["CPUExecutionProvider"]
+
+        except ImportError:
+            raise ValueError("Tried to import onnxruntime, but it was not found. Please install it using `pip install onnxruntime`")
+
+        for mdl_path, mdl_name in zip(wakeword_models, wakeword_model_names):
+            # Load openwakeword models
+            if ".tflite" in mdl_path:
+                raise ValueError("The onnx inference framework is selected, but tflite models were provided!")
+
+            sessionOptions = ort.SessionOptions()
+            sessionOptions.inter_op_num_threads = 1
+            sessionOptions.intra_op_num_threads = 1
+
+            self.models[mdl_name] = ort.InferenceSession(mdl_path, sess_options=sessionOptions,
+                                                             providers=onnx_providers)
+
+            self.model_inputs[mdl_name] = self.models[mdl_name].get_inputs()[0].shape[1]
+            self.model_outputs[mdl_name] = self.models[mdl_name].get_outputs()[0].shape[1]
+            pred_function = functools.partial(onnx_predict, self.models[mdl_name])
+            self.model_prediction_function[mdl_name] = pred_function
+
+            if class_mapping_dicts and class_mapping_dicts[wakeword_models.index(mdl_path)].get(mdl_name, None):
+                self.class_mapping[mdl_name] = class_mapping_dicts[wakeword_models.index(mdl_path)]
+            elif model_class_mappings.get(mdl_name, None):
+                self.class_mapping[mdl_name] = model_class_mappings[mdl_name]
+            else:
+                self.class_mapping[mdl_name] = {str(i): str(i) for i in range(0, self.model_outputs[mdl_name])}
+
+            # Load custom verifier models
+            if isinstance(custom_verifier_models, dict):
+                if custom_verifier_models.get(mdl_name, False):
+                    self.custom_verifier_models[mdl_name] = pickle.load(open(custom_verifier_models[mdl_name], 'rb'))
+
+            if len(self.custom_verifier_models.keys()) < len(custom_verifier_models.keys()):
+                raise ValueError(
+                    "Custom verifier models were provided, but some were not matched with a base model!"
+                    " Make sure that the keys provided in the `custom_verifier_models` dictionary argument"
+                    " exactly match that of the `.models` attribute of an instantiated openWakeWord Model object"
+                    " that has the same base models but doesn't have custom verifier models."
+                )
+
+        # Create buffer to store frame predictions
+        self.prediction_buffer: DefaultDict[str, deque] = defaultdict(partial(deque, maxlen=30))
+
+        # Create AudioFeatures object
+        self.preprocessor = AudioFeatures(onnx_providers=onnx_providers, **kwargs)
+
+    def get_parent_model_from_label(self, label):
+        """Gets the parent model associated with a given prediction label"""
+        parent_model = ""
+        for mdl in self.class_mapping.keys():
+            if label in self.class_mapping[mdl].values():
+                parent_model = mdl
+            elif label in self.class_mapping.keys() and label == mdl:
+                parent_model = mdl
+
+        return parent_model
+
+    def reset(self):
+        """Reset the prediction and audio feature buffers. Useful for re-initializing the model, though may not be efficient
+        when called too frequently."""
+        self.prediction_buffer = defaultdict(partial(deque, maxlen=30))
+        self.preprocessor.reset()
+
+    def predict(self, x: np.ndarray, patience: dict = {},
+                threshold: dict = {}, debounce_time: float = 0.0, timing: bool = False):
+        """Predict with all of the wakeword models on the input audio frames
+
+        Args:
+            x (ndarray): The input audio data to predict on with the models. Ideally should be multiples of 80 ms
+                                (1280 samples), with longer lengths reducing overall CPU usage
+                                but decreasing detection latency. Input audio with durations greater than or less
+                                than 80 ms is also supported, though this will add a detection delay of up to 80 ms
+                                as the appropriate number of samples are accumulated.
+            patience (dict): How many consecutive frames (of 1280 samples or 80 ms) above the threshold that must
+                             be observed before the current frame will be returned as non-zero.
+                             Must be provided as an a dictionary where the keys are the
+                             model names and the values are the number of frames. Can reduce false-positive
+                             detections at the cost of a lower true-positive rate.
+                             By default, this behavior is disabled.
+            threshold (dict): The threshold values to use when the `patience` or `debounce_time` behavior is enabled.
+                              Must be provided as an a dictionary where the keys are the
+                              model names and the values are the thresholds.
+            debounce_time (float): The time (in seconds) to wait before returning another non-zero prediction
+                                   after a non-zero prediction. Can preven multiple detections of the same wake-word.
+            timing (bool): Whether to return timing information of the models. Can be useful to debug and
+                           assess how efficiently models are running on the current hardware.
+
+        Returns:
+            dict: A dictionary of scores between 0 and 1 for each model, where 0 indicates no
+                  wake-word/wake-phrase detected. If the `timing` argument is true, returns a
+                  tuple of dicts containing model predictions and timing information, respectively.
+        """
+        # Check input data type
+        if not isinstance(x, np.ndarray):
+            raise ValueError(f"The input audio data (x) must by a Numpy array, instead received an object of type {type(x)}.")
+
+        # Setup timing dict
+        if timing:
+            timing_dict: Dict[str, Dict] = {}
+            timing_dict["models"] = {}
+            feature_start = time.time()
+
+        # Get audio features
+        n_prepared_samples = self.preprocessor(x)
+
+        if timing:
+            timing_dict["models"]["preprocessor"] = time.time() - feature_start
+
+        # Get predictions from model(s)
+        predictions = {}
+        for mdl in self.models.keys():
+            if timing:
+                model_start = time.time()
+
+            # Run model to get predictions
+            if n_prepared_samples > 1280:
+                group_predictions = []
+                for i in np.arange(n_prepared_samples//1280-1, -1, -1):
+                    group_predictions.extend(
+                        self.model_prediction_function[mdl](
+                            self.preprocessor.get_features(
+                                    self.model_inputs[mdl],
+                                    start_ndx=-self.model_inputs[mdl] - i
+                            )
+                        )
+                    )
+                prediction = np.array(group_predictions).max(axis=0)[None, ]
+            elif n_prepared_samples == 1280:
+                prediction = self.model_prediction_function[mdl](
+                    self.preprocessor.get_features(self.model_inputs[mdl])
+                )
+            elif n_prepared_samples < 1280:  # get previous prediction if there aren't enough samples
+                if self.model_outputs[mdl] == 1:
+                    if len(self.prediction_buffer[mdl]) > 0:
+                        prediction = [[[self.prediction_buffer[mdl][-1]]]]
+                    else:
+                        prediction = [[[0]]]
+                elif self.model_outputs[mdl] != 1:
+                    n_classes = max([int(i) for i in self.class_mapping[mdl].keys()])
+                    prediction = [[[0]*(n_classes+1)]]
+
+            if self.model_outputs[mdl] == 1:
+                predictions[mdl] = prediction[0][0][0]
+            else:
+                for int_label, cls in self.class_mapping[mdl].items():
+                    predictions[cls] = prediction[0][0][int(int_label)]
+
+            # Update scores based on custom verifier model
+            if self.custom_verifier_models != {}:
+                for cls in predictions.keys():
+                    if predictions[cls] >= self.custom_verifier_threshold:
+                        parent_model = self.get_parent_model_from_label(cls)
+                        if self.custom_verifier_models.get(parent_model, False):
+                            verifier_prediction = self.custom_verifier_models[parent_model].predict_proba(
+                                self.preprocessor.get_features(self.model_inputs[mdl])
+                            )[0][-1]
+                            predictions[cls] = verifier_prediction
+
+            # Zero predictions for first 5 frames during model initialization
+            for cls in predictions.keys():
+                if len(self.prediction_buffer[cls]) < 5:
+                    predictions[cls] = 0.0
+
+            # Get timing information
+            if timing:
+                timing_dict["models"][mdl] = time.time() - model_start
+
+        # Update scores based on thresholds or patience arguments
+        if patience != {} or debounce_time > 0:
+            if threshold == {}:
+                raise ValueError("Error! When using the `patience` argument, threshold "
+                                 "values must be provided via the `threshold` argument!")
+            if patience != {} and debounce_time > 0:
+                raise ValueError("Error! The `patience` and `debounce_time` arguments cannot be used together!")
+            for mdl in predictions.keys():
+                parent_model = self.get_parent_model_from_label(mdl)
+                if predictions[mdl] != 0.0:
+                    if parent_model in patience.keys():
+                        scores = np.array(self.prediction_buffer[mdl])[-patience[parent_model]:]
+                        if (scores >= threshold[parent_model]).sum() < patience[parent_model]:
+                            predictions[mdl] = 0.0
+                    elif debounce_time > 0:
+                        if parent_model in threshold.keys():
+                            n_frames = int(np.ceil(debounce_time/(n_prepared_samples/16000)))
+                            recent_predictions = np.array(self.prediction_buffer[mdl])[-n_frames:]
+                            if predictions[mdl] >= threshold[parent_model] and \
+                               (recent_predictions >= threshold[parent_model]).sum() > 0:
+                                predictions[mdl] = 0.0
+
+        # Update prediction buffer
+        for mdl in predictions.keys():
+            self.prediction_buffer[mdl].append(predictions[mdl])
+
+        if timing:
+            return predictions, timing_dict
+        else:
+            return predictions
+
+    def predict_clip(self, clip: Union[str, np.ndarray], padding: int = 1, chunk_size=1280, **kwargs):
+        """Predict on an full audio clip, simulating streaming prediction.
+        The input clip must bit a 16-bit, 16 khz, single-channel WAV file.
+
+        Args:
+            clip (Union[str, np.ndarray]): The path to a 16-bit PCM, 16 khz, single-channel WAV file,
+                                           or an 1D array containing the same type of data
+            padding (int): How many seconds of silence to pad the start/end of the clip with
+                            to make sure that short clips can be processed correctly (default: 1)
+            chunk_size (int): The size (in samples) of each chunk of audio to pass to the model
+            kwargs: Any keyword arguments to pass to the class `predict` method
+
+        Returns:
+            list: A list containing the frame-level prediction dictionaries for the audio clip
+        """
+        if isinstance(clip, str):
+            # Load audio clip as 16-bit PCM data
+            with wave.open(clip, mode='rb') as f:
+                # Load WAV clip frames
+                data = np.frombuffer(f.readframes(f.getnframes()), dtype=np.int16)
+        elif isinstance(clip, np.ndarray):
+            data = clip
+
+        if padding:
+            data = np.concatenate(
+                (
+                    np.zeros(16000*padding).astype(np.int16),
+                    data,
+                    np.zeros(16000*padding).astype(np.int16)
+                )
+            )
+
+        # Iterate through clip, getting predictions
+        predictions = []
+        step_size = chunk_size
+        for i in range(0, data.shape[0]-step_size, step_size):
+            predictions.append(self.predict(data[i:i+step_size], **kwargs))
+
+        return predictions
+
+    def _get_positive_prediction_frames(
+            self,
+            file: str,
+            threshold: float = 0.5,
+            return_type: str = "features",
+            **kwargs
+            ):
+        """
+        Gets predictions for the input audio data, and returns the audio features (embeddings)
+        or audio data for all of the frames with a score above the `threshold` argument.
+        Can be a useful way to collect false-positive predictions.
+
+        Args:
+            file (str): The path to a 16-bit 16khz WAV audio file to process
+            threshold (float): The minimum score required for a frame of audio features
+                               to be returned.
+            return_type (str): The type of data to return when a positive prediction is
+                               detected. Can be either 'features' or 'audio' to return
+                               audio embeddings or raw audio data, respectively.
+            kwargs: Any keyword arguments to pass to the class `predict` method
+
+        Returns:
+            dict: A dictionary with filenames as keys and  N x M arrays as values,
+                  where N is the number of examples and M is the number
+                  of audio features, depending on the model input shape.
+        """
+        # Load audio clip as 16-bit PCM data
+        with wave.open(file, mode='rb') as f:
+            # Load WAV clip frames
+            data = np.frombuffer(f.readframes(f.getnframes()), dtype=np.int16)
+
+        # Iterate through clip, getting predictions
+        positive_data = defaultdict(list)
+        step_size = 1280
+        for i in range(0, data.shape[0]-step_size, step_size):
+            predictions = self.predict(data[i:i+step_size], **kwargs)
+            for lbl in predictions.keys():
+                if predictions[lbl] >= threshold:
+                    mdl = self.get_parent_model_from_label(lbl)
+                    features = self.preprocessor.get_features(self.model_inputs[mdl])
+                    if return_type == 'features':
+                        positive_data[lbl].append(features)
+                    if return_type == 'audio':
+                        context = data[max(0, i - 16000*3):i + 16000]
+                        if len(context) == 16000*4:
+                            positive_data[lbl].append(context)
+
+        positive_data_combined = {}
+        for lbl in positive_data.keys():
+            positive_data_combined[lbl] = np.vstack(positive_data[lbl])
+
+        return positive_data_combined

--- a/src/glados/openwakeword/utils.py
+++ b/src/glados/openwakeword/utils.py
@@ -1,0 +1,401 @@
+# Copyright 2022 David Scripka. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Modifications by reisbauer03
+#   stripped every top-level-element not used for GLaDOS, i.e. everything except AudioFeatures and re_arg
+#   stripped tflite, forcing usage of onnxruntime
+#   swapped 'device' parameter on __init__ for parameter 'onnx_providers', adapted usage
+
+# Imports
+import os
+import numpy as np
+import pathlib
+from collections import deque
+from multiprocessing.pool import ThreadPool
+import logging
+from typing import Union, List, Callable, Deque
+
+
+# Base class for computing audio features using Google's speech_embedding
+# model (https://tfhub.dev/google/speech_embedding/1)
+class AudioFeatures():
+    """
+    A class for creating audio features from audio data, including melspectograms and Google's
+    `speech_embedding` features.
+    """
+    def __init__(self,
+                 melspec_model_path: str = "",
+                 embedding_model_path: str = "",
+                 sr: int = 16000,
+                 ncpu: int = 1,
+                 onnx_providers: list[str] = None
+                 ):
+        """
+        Initialize the AudioFeatures object.
+
+        Args:
+            melspec_model_path (str): The path to the model for computing melspectograms from audio data
+            embedding_model_path (str): The path to the model for Google's `speech_embedding` model
+            sr (int): The sample rate of the audio (default: 16000 khz)
+            ncpu (int): The number of CPUs to use when computing melspectrograms and audio features (default: 1)
+            onnx_providers (list[str): list of ONNX providers to use. Default: ["CPUExecutionProvider"]
+        """
+        # Initialize the models with the appropriate framework
+        try:
+            import onnxruntime as ort
+        except ImportError:
+            raise ValueError("Tried to import onnxruntime, but it was not found. Please install it using `pip install onnxruntime`")
+
+        if melspec_model_path == "":
+            melspec_model_path = os.path.join(pathlib.Path(__file__).parent.resolve(), "resources", "models", "melspectrogram.onnx")
+        if embedding_model_path == "":
+            embedding_model_path = os.path.join(pathlib.Path(__file__).parent.resolve(), "resources", "models", "embedding_model.onnx")
+
+        if ".tflite" in melspec_model_path or ".tflite" in embedding_model_path:
+            raise ValueError("The onnx inference framework is selected, but tflite models were provided!")
+
+        # Initialize ONNX options
+        if onnx_providers is None:
+            onnx_providers = ["CPUExecutionProvider"]
+
+        sessionOptions = ort.SessionOptions()
+        sessionOptions.inter_op_num_threads = ncpu
+        sessionOptions.intra_op_num_threads = ncpu
+
+        # Melspectrogram model
+        self.melspec_model = ort.InferenceSession(melspec_model_path, sess_options=sessionOptions,
+                                                  providers=onnx_providers)
+        self.onnx_execution_provider = self.melspec_model.get_providers()[0]
+        self.melspec_model_predict = lambda x: self.melspec_model.run(None, {'input': x})
+
+        # Audio embedding model
+        self.embedding_model = ort.InferenceSession(embedding_model_path, sess_options=sessionOptions,
+                                                    providers=onnx_providers)
+        self.embedding_model_predict = lambda x: self.embedding_model.run(None, {'input_1': x})[0].squeeze()
+
+        # Create databuffers with empty/random data
+        self.raw_data_buffer: Deque = deque(maxlen=sr*10)
+        self.melspectrogram_buffer = np.ones((76, 32))  # n_frames x num_features
+        self.melspectrogram_max_len = 10*97  # 97 is the number of frames in 1 second of 16hz audio
+        self.accumulated_samples = 0  # the samples added to the buffer since the audio preprocessor was last called
+        self.raw_data_remainder = np.empty(0)
+        self.feature_buffer = self._get_embeddings(np.random.randint(-1000, 1000, 16000*4).astype(np.int16))
+        self.feature_buffer_max_len = 120  # ~10 seconds of feature buffer history
+
+    def reset(self):
+        """Reset the internal buffers"""
+        self.raw_data_buffer.clear()
+        self.melspectrogram_buffer = np.ones((76, 32))
+        self.accumulated_samples = 0
+        self.raw_data_remainder = np.empty(0)
+        self.feature_buffer = self._get_embeddings(np.random.randint(-1000, 1000, 16000*4).astype(np.int16))
+
+    def _get_melspectrogram(self, x: Union[np.ndarray, List], melspec_transform: Callable = lambda x: x/10 + 2):
+        """
+        Function to compute the mel-spectrogram of the provided audio samples.
+
+        Args:
+            x (Union[np.ndarray, List]): The input audio data to compute the melspectrogram from
+            melspec_transform (Callable): A function to transform the computed melspectrogram. Defaults to a transform
+                                          that makes the ONNX melspectrogram model closer to the native Tensorflow
+                                          implementation from Google (https://tfhub.dev/google/speech_embedding/1).
+
+        Return:
+            np.ndarray: The computed melspectrogram of the input audio data
+        """
+        # Get input data and adjust type/shape as needed
+        x = np.array(x).astype(np.int16) if isinstance(x, list) else x
+        if x.dtype != np.int16:
+            raise ValueError("Input data must be 16-bit integers (i.e., 16-bit PCM audio)."
+                             f"You provided {x.dtype} data.")
+        x = x[None, ] if len(x.shape) < 2 else x
+        x = x.astype(np.float32) if x.dtype != np.float32 else x
+
+        # Get melspectrogram
+        outputs = self.melspec_model_predict(x)
+        spec = np.squeeze(outputs[0])
+
+        # Arbitrary transform of melspectrogram
+        spec = melspec_transform(spec)
+
+        return spec
+
+    def _get_embeddings_from_melspec(self, melspec):
+        """
+        Computes the Google `speech_embedding` features from a melspectrogram input
+
+        Args:
+            melspec (np.ndarray): The input melspectrogram
+
+        Returns:
+            np.ndarray: The computed audio features/embeddings
+        """
+        if melspec.shape[0] != 1:
+            melspec = melspec[None, ]
+        embedding = self.embedding_model_predict(melspec)
+        return embedding
+
+    def _get_embeddings(self, x: np.ndarray, window_size: int = 76, step_size: int = 8, **kwargs):
+        """Function to compute the embeddings of the provide audio samples."""
+        spec = self._get_melspectrogram(x, **kwargs)
+        windows = []
+        for i in range(0, spec.shape[0], 8):
+            window = spec[i:i+window_size]
+            if window.shape[0] == window_size:  # truncate short windows
+                windows.append(window)
+
+        batch = np.expand_dims(np.array(windows), axis=-1).astype(np.float32)
+        embedding = self.embedding_model_predict(batch)
+        return embedding
+
+    def get_embedding_shape(self, audio_length: float, sr: int = 16000):
+        """Function that determines the size of the output embedding array for a given audio clip length (in seconds)"""
+        x = (np.random.uniform(-1, 1, int(audio_length*sr))*32767).astype(np.int16)
+        return self._get_embeddings(x).shape
+
+    def _get_melspectrogram_batch(self, x, batch_size=128, ncpu=1):
+        """
+        Compute the melspectrogram of the input audio samples in batches.
+
+        Note that the optimal performance will depend in the interaction between the device,
+        batch size, and ncpu (if a CPU device is used). The user is encouraged
+        to experiment with different values of these parameters to identify
+        which combination is best for their data, as often differences of 1-4x are seen.
+
+        Args:
+            x (ndarray): A numpy array of 16 khz input audio data in shape (N, samples).
+                        Assumes that all of the audio data is the same length (same number of samples).
+            batch_size (int): The batch size to use when computing the melspectrogram
+            ncpu (int): The number of CPUs to use when computing the melspectrogram. This argument has
+                        no effect if the underlying model is executing on a GPU.
+
+        Returns:
+            ndarray: A numpy array of shape (N, frames, melbins) containing the melspectrogram of
+                    all N input audio examples
+        """
+
+        # Prepare ThreadPool object, if needed for multithreading
+        pool = None
+        if "CPU" in self.onnx_execution_provider:
+            pool = ThreadPool(processes=ncpu)
+
+        # Make batches
+        n_frames = int(np.ceil(x.shape[1]/160-3))
+        mel_bins = 32  # fixed by melspectrogram model
+        melspecs = np.empty((x.shape[0], n_frames, mel_bins), dtype=np.float32)
+        for i in range(0, max(batch_size, x.shape[0]), batch_size):
+            batch = x[i:i+batch_size]
+
+            if "CUDA" in self.onnx_execution_provider:
+                result = self._get_melspectrogram(batch)
+
+            elif pool:
+                chunksize = batch.shape[0]//ncpu if batch.shape[0] >= ncpu else 1
+                result = np.array(pool.map(self._get_melspectrogram,
+                                           batch, chunksize=chunksize))
+
+            melspecs[i:i+batch_size, :, :] = result.squeeze()
+
+        # Cleanup ThreadPool
+        if pool:
+            pool.close()
+
+        return melspecs
+
+    def _get_embeddings_batch(self, x, batch_size=128, ncpu=1):
+        """
+        Compute the embeddings of the input melspectrograms in batches.
+
+        Note that the optimal performance will depend in the interaction between the device,
+        batch size, and ncpu (if a CPU device is used). The user is encouraged
+        to experiment with different values of these parameters to identify
+        which combination is best for their data, as often differences of 1-4x are seen.
+
+        Args:
+            x (ndarray): A numpy array of melspectrograms of shape (N, frames, melbins).
+                        Assumes that all of the melspectrograms have the same shape.
+            batch_size (int): The batch size to use when computing the embeddings
+            ncpu (int): The number of CPUs to use when computing the embeddings. This argument has
+                        no effect if the underlying model is executing on a GPU.
+
+        Returns:
+            ndarray: A numpy array of shape (N, frames, embedding_dim) containing the embeddings of
+                    all N input melspectrograms
+        """
+        # Ensure input is the correct shape
+        if x.shape[1] < 76:
+            raise ValueError("Embedding model requires the input melspectrograms to have at least 76 frames")
+
+        # Prepare ThreadPool object, if needed for multithreading
+        pool = None
+        if "CPU" in self.onnx_execution_provider:
+            pool = ThreadPool(processes=ncpu)
+
+        # Calculate array sizes and make batches
+        n_frames = (x.shape[1] - 76)//8 + 1
+        embedding_dim = 96  # fixed by embedding model
+        embeddings = np.empty((x.shape[0], n_frames, embedding_dim), dtype=np.float32)
+
+        batch = []
+        ndcs = []
+        for ndx, melspec in enumerate(x):
+            window_size = 76
+            for i in range(0, melspec.shape[0], 8):
+                window = melspec[i:i+window_size]
+                if window.shape[0] == window_size:  # ignore windows that are too short (truncates end of clip)
+                    batch.append(window)
+            ndcs.append(ndx)
+
+            if len(batch) >= batch_size or ndx+1 == x.shape[0]:
+                batch = np.array(batch).astype(np.float32)
+                if "CUDA" in self.onnx_execution_provider:
+                    result = self.embedding_model_predict(batch)
+
+                elif pool:
+                    chunksize = batch.shape[0]//ncpu if batch.shape[0] >= ncpu else 1
+                    result = np.array(pool.map(self._get_embeddings_from_melspec,
+                                      batch, chunksize=chunksize))
+
+                for j, ndx2 in zip(range(0, result.shape[0], n_frames), ndcs):
+                    embeddings[ndx2, :, :] = result[j:j+n_frames]
+
+                batch = []
+                ndcs = []
+
+        # Cleanup ThreadPool
+        if pool:
+            pool.close()
+
+        return embeddings
+
+    def embed_clips(self, x, batch_size=128, ncpu=1):
+        """
+        Compute the embeddings of the input audio clips in batches.
+
+        Note that the optimal performance will depend in the interaction between the device,
+        batch size, and ncpu (if a CPU device is used). The user is encouraged
+        to experiment with different values of these parameters to identify
+        which combination is best for their data, as often differences of 1-4x are seen.
+
+        Args:
+            x (ndarray): A numpy array of 16 khz input audio data in shape (N, samples).
+                        Assumes that all of the audio data is the same length (same number of samples).
+            batch_size (int): The batch size to use when computing the embeddings
+            ncpu (int): The number of CPUs to use when computing the melspectrogram. This argument has
+                        no effect if the underlying model is executing on a GPU.
+
+        Returns:
+            ndarray: A numpy array of shape (N, frames, embedding_dim) containing the embeddings of
+                    all N input audio clips
+        """
+
+        # Compute melspectrograms
+        melspecs = self._get_melspectrogram_batch(x, batch_size=batch_size, ncpu=ncpu)
+
+        # Compute embeddings from melspectrograms
+        embeddings = self._get_embeddings_batch(melspecs[:, :, :, None], batch_size=batch_size, ncpu=ncpu)
+
+        return embeddings
+
+    def _streaming_melspectrogram(self, n_samples):
+        """Note! There seem to be some slight numerical issues depending on the underlying audio data
+        such that the streaming method is not exactly the same as when the melspectrogram of the entire
+        clip is calculated. It's unclear if this difference is significant and will impact model performance.
+        In particular padding with 0 or very small values seems to demonstrate the differences well.
+        """
+        if len(self.raw_data_buffer) < 400:
+            raise ValueError("The number of input frames must be at least 400 samples @ 16khz (25 ms)!")
+
+        self.melspectrogram_buffer = np.vstack(
+            (self.melspectrogram_buffer, self._get_melspectrogram(list(self.raw_data_buffer)[-n_samples-160*3:]))
+        )
+
+        if self.melspectrogram_buffer.shape[0] > self.melspectrogram_max_len:
+            self.melspectrogram_buffer = self.melspectrogram_buffer[-self.melspectrogram_max_len:, :]
+
+    def _buffer_raw_data(self, x):
+        """
+        Adds raw audio data to the input buffer
+        """
+        self.raw_data_buffer.extend(x.tolist() if isinstance(x, np.ndarray) else x)
+
+    def _streaming_features(self, x):
+        # Add raw audio data to buffer, temporarily storing extra frames if not an even number of 80 ms chunks
+        processed_samples = 0
+
+        if self.raw_data_remainder.shape[0] != 0:
+            x = np.concatenate((self.raw_data_remainder, x))
+            self.raw_data_remainder = np.empty(0)
+
+        if self.accumulated_samples + x.shape[0] >= 1280:
+            remainder = (self.accumulated_samples + x.shape[0]) % 1280
+            if remainder != 0:
+                x_even_chunks = x[0:-remainder]
+                self._buffer_raw_data(x_even_chunks)
+                self.accumulated_samples += len(x_even_chunks)
+                self.raw_data_remainder = x[-remainder:]
+            elif remainder == 0:
+                self._buffer_raw_data(x)
+                self.accumulated_samples += x.shape[0]
+                self.raw_data_remainder = np.empty(0)
+        else:
+            self.accumulated_samples += x.shape[0]
+            self._buffer_raw_data(x)
+
+        # Only calculate melspectrogram once minimum samples are accumulated
+        if self.accumulated_samples >= 1280 and self.accumulated_samples % 1280 == 0:
+            self._streaming_melspectrogram(self.accumulated_samples)
+
+            # Calculate new audio embeddings/features based on update melspectrograms
+            for i in np.arange(self.accumulated_samples//1280-1, -1, -1):
+                ndx = -8*i
+                ndx = ndx if ndx != 0 else len(self.melspectrogram_buffer)
+                x = self.melspectrogram_buffer[-76 + ndx:ndx].astype(np.float32)[None, :, :, None]
+                if x.shape[1] == 76:
+                    self.feature_buffer = np.vstack((self.feature_buffer,
+                                                    self.embedding_model_predict(x)))
+
+            # Reset raw data buffer counter
+            processed_samples = self.accumulated_samples
+            self.accumulated_samples = 0
+
+        if self.feature_buffer.shape[0] > self.feature_buffer_max_len:
+            self.feature_buffer = self.feature_buffer[-self.feature_buffer_max_len:, :]
+
+        return processed_samples if processed_samples != 0 else self.accumulated_samples
+
+    def get_features(self, n_feature_frames: int = 16, start_ndx: int = -1):
+        if start_ndx != -1:
+            end_ndx = start_ndx + int(n_feature_frames) \
+                if start_ndx + n_feature_frames != 0 else len(self.feature_buffer)
+            return self.feature_buffer[start_ndx:end_ndx, :][None, ].astype(np.float32)
+        else:
+            return self.feature_buffer[int(-1*n_feature_frames):, :][None, ].astype(np.float32)
+
+    def __call__(self, x):
+        return self._streaming_features(x)
+
+# Handle deprecated arguments and naming (thanks to https://stackoverflow.com/a/74564394)
+def re_arg(kwarg_map):
+    def decorator(func):
+        def wrapped(*args, **kwargs):
+            new_kwargs = {}
+            for k, v in kwargs.items():
+                if k in kwarg_map:
+                    logging.warning(f"DEPRECATION: keyword argument '{k}' is no longer valid and "
+                                    f"will be removed in future releases. Use '{kwarg_map[k]}' instead.")
+                new_kwargs[kwarg_map.get(k, k)] = v
+            return func(*args, **new_kwargs)
+        return wrapped
+    return decorator


### PR DESCRIPTION
This PR adds a new wake word recognition based on [OpenWakeWord](https://github.com/dscripka/openWakeWord), because I'm definitely unable to pronounce "GLaDOS" in a way the ASR recognizes.

- The functionality is a stripped version of the OpenWakeWord code: originally I wanted to add it as a dependency, but the package conflicts with `onnxruntime-gpu` and always adds a dependency on `tflite`, so I took `model.py` and `utils.py` from their code and integrated them into this project. The original license is preserved, original authorship is clearly visible in the files from the OpenWakeWord project. The Apache 2.0 license is compatible with the MIT license used for GLaDOS.
- New configuration parameter `wake_word_model_path`: if this is set to a OpenWakeWord `.onnx` model, recognized text is only passed to the LLM if it contains the wake word. This configuration option takes precedence over the old `wake_word` option (if set).
- 2 new model files are automatically downloaded with `glados download`, I suspect you will want to change the URLs.
- No performance impact if the option isn't enabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional ONNX wake-word model via new configuration field; wake word must be exactly one word.
  * Model-based wake-word detection with improved streaming feature extraction for more reliable, lower-latency gating (ASR text gating kept as fallback).

* **Chores**
  * Added OpenWakeWord model artifacts to download/verification registry and included Apache 2.0 license.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->