### PR TITLE
feat: upgrade MiniMax default model to M3

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,13 +354,13 @@ api_key: ""  # if needed
 
 You can use any OpenAI-compatible cloud API. Example configs are provided in `configs/`:
 
-**MiniMax** — high-performance models with 204K context and built-in reasoning:
+**MiniMax** — high-performance models with 512K context and built-in reasoning:
 ```yaml
-llm_model: "MiniMax-M2.7"
+llm_model: "MiniMax-M3"
 completion_url: "https://api.minimax.io/v1/chat/completions"
 api_key: "your-minimax-api-key"
 ```
-See `configs/minimax_config.yaml` for a complete configuration. Models: `MiniMax-M2.7` (latest flagship, default), `MiniMax-M2.7-highspeed` (low-latency), `MiniMax-M2.5`, `MiniMax-M2.5-highspeed`.
+See `configs/minimax_config.yaml` for a complete configuration. Models: `MiniMax-M3` (latest flagship, default), `MiniMax-M2.7` (previous generation), `MiniMax-M2.7-highspeed` (low-latency).
 
 **OpenRouter** — access multiple models through one API:
 ```yaml

--- a/configs/minimax_config.yaml
+++ b/configs/minimax_config.yaml
@@ -2,20 +2,19 @@
 # Uses MiniMax's OpenAI-compatible API endpoint.
 #
 # Setup:
-#   1. Get an API key from https://platform.minimaxi.com/
+#   1. Get an API key from https://platform.minimax.io/
 #   2. Set your API key below or via the MINIMAX_API_KEY environment variable
 #
 # Available models:
-#   - MiniMax-M2.7           Latest flagship model with enhanced reasoning and coding
-#   - MiniMax-M2.7-highspeed High-speed version of M2.7 for low-latency scenarios
-#   - MiniMax-M2.5           204K context, best quality
-#   - MiniMax-M2.5-highspeed 204K context, optimized for speed
+#   - MiniMax-M3             Latest flagship, 512K context, 128K max output, image input
+#   - MiniMax-M2.7           Previous generation, 204K context, with reasoning
+#   - MiniMax-M2.7-highspeed Previous generation, low-latency variant
 #
-# Note: MiniMax models (M2.5, M2.7) support thinking/reasoning tags (<think>...</think>),
+# Note: MiniMax models (M2.7, M3) support thinking/reasoning tags (<think>...</think>),
 #       which GLaDOS will automatically extract and log separately from speech.
 
 Glados:
-  llm_model: "MiniMax-M2.7"
+  llm_model: "MiniMax-M3"
   completion_url: "https://api.minimax.io/v1/chat/completions"
   api_key: null  # Set your MiniMax API key here, or use MINIMAX_API_KEY environment variable
   interruptible: true

--- a/src/glados/core/llm_processor.py
+++ b/src/glados/core/llm_processor.py
@@ -33,7 +33,7 @@ class LanguageModelProcessor:
 
     PUNCTUATION_SET: ClassVar[set[str]] = {".", "!", "?", ":", ";", "?!", "\n", "\n\n"}
 
-    # Standard thinking tags (GLM-4.7, MiniMax M2.1/M2.5/M2.7, DeepSeek, etc.)
+    # Standard thinking tags (GLM-4.7, MiniMax M2.7/M3, DeepSeek, etc.)
     THINKING_OPEN_TAGS: ClassVar[tuple[str, ...]] = ("<think>", "<thinking>", "<reasoning>")
     THINKING_CLOSE_TAGS: ClassVar[tuple[str, ...]] = ("</think>", "</thinking>", "</reasoning>")
 
@@ -411,7 +411,7 @@ class LanguageModelProcessor:
         Extract thinking tags from streaming chunk, returning only speakable content.
 
         Supports two formats:
-        1. Standard: <think>...</think> (GLM-4.7, MiniMax M2.1/M2.5/M2.7, DeepSeek)
+        1. Standard: <think>...</think> (GLM-4.7, MiniMax M2.7/M3, DeepSeek)
         2. Harmony: <|channel|>analysis vs <|channel|>final (GPT-OSS-120B)
 
         Args:


### PR DESCRIPTION
## Summary
Upgrade MiniMax model configuration to use M3 as the default model.

## Changes
- Add MiniMax-M3 to the model selection list and set as default in `configs/minimax_config.yaml`
- Keep MiniMax-M2.7 and MiniMax-M2.7-highspeed as available alternatives
- Remove older models (M2.5, M2.5-highspeed)
- Update README model list and `llm_processor.py` thinking-tag docstrings
- Update platform URL to `https://platform.minimax.io/`

## Why
MiniMax-M3 is the latest flagship model with a 512K context window, up to 128K output, and image input support.

## Testing
- Config and documentation changes only — no functional code modified
- Existing tests unaffected (no MiniMax-specific tests in this project)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated MiniMax documentation to reflect MiniMax-M3 as the default model with 512K context support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->