### PR TITLE
Fix glados TTS returning 2-D audio that crashes the playback callback

### DIFF
--- a/src/glados/TTS/tts_glados.py
+++ b/src/glados/TTS/tts_glados.py
@@ -203,7 +203,7 @@ class SpeechSynthesizer:
         audio_chunks = [self._synthesize_ids_to_audio(phoneme_ids) for phoneme_ids in phoneme_ids_list]
 
         if audio_chunks:
-            audio: NDArray[np.float32] = np.concatenate(audio_chunks, axis=1).T
+            audio: NDArray[np.float32] = np.concatenate(audio_chunks, axis=1).ravel()
             return audio
         return np.array([], dtype=np.float32)
 


### PR DESCRIPTION
## Summary

Voice mode crashes with a `ValueError` in the sounddevice playback callback whenever the default `voice: "glados"` TTS is used. The root cause is that `SpeechSynthesizer.generate_speech_audio()` returns a **2-D `(N, 1)` array** instead of 1-D audio. This PR fixes it by flattening with `.ravel()` instead of transposing — a one-line change.

## Symptom

With the default config (`voice: "glados"`), as soon as the assistant starts speaking, playback dies with:

```
ValueError: could not broadcast input array from shape (576,1) into shape (576,)
```

raised inside `stream_callback` in `src/glados/audio_io/sounddevice_io.py`:

```python
outdata[:chunk_size, 0] = audio_data[position : position + chunk_size]
```

`outdata[:chunk_size, 0]` is a 1-D view of length `chunk_size` (576 = one callback block), but `audio_data[position : position + chunk_size]` slices a `(N, 1)` array along axis 0, producing a `(576, 1)` slice that cannot broadcast into shape `(576,)`. Since the exception escapes a sounddevice callback, speech playback aborts.

## Root cause

In `src/glados/TTS/tts_glados.py`, `generate_speech_audio()` did:

```python
audio: NDArray[np.float32] = np.concatenate(audio_chunks, axis=1).T
```

Each chunk returned by the ONNX VITS session (`_synthesize_ids_to_audio`) has shape `(1, N)` (verified at runtime, e.g. `(1, 63744)` for a short sentence). So:

- `np.concatenate(chunks, axis=1)` → `(1, total)`
- `.T` → `(total, 1)` — still 2-D, just transposed

The rest of the pipeline expects 1-D audio (`shape (total,)`).

### Why this wasn't caught earlier

- **Kokoro voices are unaffected**: `tts_kokoro.py` already returns 1-D arrays, so anyone running a non-default voice never hits this.
- **`glados say` masks the bug**: the one-shot `say` path plays audio via `sd.play()`, which happily accepts a `(N, 1)` column array as mono. Only the streaming engine callback, which indexes `outdata[:chunk_size, 0]`, requires 1-D.

## Fix

```diff
-            audio: NDArray[np.float32] = np.concatenate(audio_chunks, axis=1).T
+            audio: NDArray[np.float32] = np.concatenate(audio_chunks, axis=1).ravel()
```

`.ravel()` flattens `(1, total)` to `(total,)` without copying (the concatenated array is already contiguous) and preserves sample order and values.

## Verification

Ran the actual ONNX model through both code paths:

- Raw chunk shape from the ONNX session: `(1, 63744)` — confirms the 2-D source.
- Old expression on those chunks: shape `(63744, 1)`; simulating the callback assignment `outdata[:576, 0] = audio[0:576]` reproduces the exact `ValueError: could not broadcast input array from shape (576,1) into shape (576,)`.
- Fixed expression on the same chunks: shape `(63744,)`, bit-identical samples (`np.array_equal` with the old result raveled), and the callback assignment succeeds.
- `generate_speech_audio()` after the fix returns 1-D `float32` and voice mode plays back normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected audio sample ordering in speech synthesis output when concatenating multiple audio chunks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->